### PR TITLE
name threads in websocket poolExecutor

### DIFF
--- a/octobot_trading/exchanges/websockets/octobot_websocket.py
+++ b/octobot_trading/exchanges/websockets/octobot_websocket.py
@@ -154,7 +154,9 @@ class OctoBotWebSocketClient(AbstractWebsocket):
                 self.is_handling_ohlcv or \
                 self.is_handling_recent_trades:
             try:
-                self.octobot_websockets_executors = ThreadPoolExecutor(max_workers=len(self.octobot_websockets))
+                self.octobot_websockets_executors = ThreadPoolExecutor(
+                    max_workers=len(self.octobot_websockets),
+                    thread_name_prefix=f"{self.get_name()}-{self.exchange_name}-pool-executor")
                 for websocket in self.octobot_websockets:
                     asyncio.get_event_loop().run_in_executor(self.octobot_websockets_executors, websocket.start)
                 self.is_websocket_running = True


### PR DESCRIPTION
usage ex:
![image](https://user-images.githubusercontent.com/9078616/73590738-3e808b80-44e6-11ea-966f-c59e8ad7e97b.png)
