### PR TITLE
[Requirement] Fix cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ OctoBot-Commons>=1.3.5, <1.4
 
 # Exchange connection requirements
 ccxt==1.25.75
-cryptography==2.9
+cryptography # Never specify a version (managed by https://github.com/Drakkar-Software/OctoBot-PyPi-Linux-Deployer)
 
 # CLI requirements
 click==7.1.1


### PR DESCRIPTION
cryptography package version shouldn't be specified.
It's managed by https://github.com/Drakkar-Software/OctoBot-PyPi-Linux-Deployer.