### PR TITLE
fix order states tests coroutine warnings

### DIFF
--- a/tests/orders/states/test_cancel_order_state.py
+++ b/tests/orders/states/test_cancel_order_state.py
@@ -26,6 +26,8 @@ pytestmark = pytest.mark.asyncio
 
 async def test_on_order_refresh_successful(sell_limit_order):
     sell_limit_order.status = OrderStatus.CANCELED
+    sell_limit_order.exchange_manager.is_backtesting = True
     await sell_limit_order.initialize()
     await sell_limit_order.state.on_order_refresh_successful()
     assert sell_limit_order.is_cancelled()
+    sell_limit_order.clear()

--- a/tests/orders/states/test_close_order_state.py
+++ b/tests/orders/states/test_close_order_state.py
@@ -25,6 +25,8 @@ pytestmark = pytest.mark.asyncio
 
 async def test_on_order_refresh_successful(sell_limit_order):
     sell_limit_order.status = OrderStatus.CLOSED
+    sell_limit_order.exchange_manager.is_backtesting = True
     await sell_limit_order.initialize()
     await sell_limit_order.state.on_order_refresh_successful()
     assert sell_limit_order.is_closed()
+    sell_limit_order.clear()

--- a/tests/orders/states/test_fill_order_state.py
+++ b/tests/orders/states/test_fill_order_state.py
@@ -24,6 +24,8 @@ pytestmark = pytest.mark.asyncio
 
 async def test_on_order_refresh_successful(buy_limit_order):
     buy_limit_order.status = OrderStatus.FILLED
+    buy_limit_order.exchange_manager.is_backtesting = True
     await buy_limit_order.initialize()
     await buy_limit_order.state.on_order_refresh_successful()
     assert buy_limit_order.is_closed()
+    buy_limit_order.clear()

--- a/tests/orders/states/test_open_order_state.py
+++ b/tests/orders/states/test_open_order_state.py
@@ -25,6 +25,7 @@ pytestmark = pytest.mark.asyncio
 
 
 async def test_on_order_refresh_successful(buy_limit_order):
+    buy_limit_order.exchange_manager.is_backtesting = True
     await buy_limit_order.initialize()
     await buy_limit_order.state.on_order_refresh_successful()
     assert buy_limit_order.state.state is OrderStates.OPEN


### PR DESCRIPTION
fixes `RuntimeWarning: coroutine 'LimitOrder.update_order_status' was never awaited` warning