### PR TITLE
WIP attempt to fix order states

### DIFF
--- a/octobot_trading/channels/orders.py
+++ b/octobot_trading/channels/orders.py
@@ -48,8 +48,7 @@ class OrdersProducer(ExchangeChannelProducer):
                     else:
                         await self._handle_open_order_update(symbol, order, order_id, is_from_bot, is_new_order)
 
-            if not are_closed:
-                await self._handle_post_open_order_update(symbol, orders, has_new_order)
+            await self._handle_post_open_order_update(symbol, orders, has_new_order)
 
         except CancelledError:
             self.logger.info("Update tasks cancelled.")

--- a/octobot_trading/exchanges/data/exchange_personal_data.py
+++ b/octobot_trading/exchanges/data/exchange_personal_data.py
@@ -156,7 +156,10 @@ class ExchangePersonalData(Initializable):
         :return: True if the closed order has been created or updated
         """
         try:
-            return await self.orders_manager.upsert_order_close_from_raw(order_id, raw_order) is not None
+            order = await self.orders_manager.upsert_order_close_from_raw(order_id, raw_order)
+            if order is not None:
+                order.state.on_order_refresh_successful()
+            return order is not None
         except Exception as e:
             self.logger.exception(e, True, f"Failed to update order : {e}")
             return False


### PR DESCRIPTION
current issue: order sync is called twice: on the 2nd call since the order is cleared, this issues occurs:
```
2020-08-24 01:32:58,734 INFO     Order | 103791843    KNC/BTC | BUY_LIMIT | Price : 0.00014624 | Quantity : 29.0 | State : closed | id : 103791843 closed on binance
2020-08-24 01:32:58,738 ERROR    root                 
NoneType: None
2020-08-24 01:32:58,740 ERROR    root                 <class 'AttributeError'>: 'NoneType' object has no attribute 'exchange_name'
NoneType: None
 2020-08-24 01:32:58,741 ERROR    Order | 103791843    'NoneType' object has no attribute 'exchange_personal_data'
Traceback (most recent call last):
  File "octobot_trading/orders/states/close_order_state.py", line 53, in octobot_trading.orders.states.close_order_state.CloseOrderState.terminate
AttributeError: 'NoneType' object has no attribute 'exchange_personal_data'
```