### PR TITLE
WIP Order state candidate: single task check

### DIFF
--- a/octobot_trading/channels/orders.py
+++ b/octobot_trading/channels/orders.py
@@ -99,11 +99,12 @@ class OrdersProducer(ExchangeChannelProducer):
                 await get_chan(BALANCE_CHANNEL, self.channel.exchange_manager.id).get_internal_producer(). \
                     refresh_real_trader_portfolio()
 
-    async def update_order_from_exchange(self, order, should_notify=False) -> bool:
+    async def update_order_from_exchange(self, order, should_notify=False, allow_tasks=False) -> bool:
         """
         Update Order from exchange
         :param order: the order to update
         :param should_notify: if Orders channel consumers should be notified
+        :param allow_tasks: if a task can be created in this order update process
         :return: True if the order was updated
         """
         self.logger.debug(f"Requested update for {order} on {order.exchange_manager.exchange_name}")
@@ -114,7 +115,7 @@ class OrdersProducer(ExchangeChannelProducer):
             self.logger.debug(f"Received update for {order} on {order.exchange_manager.exchange_name}: {raw_order}")
 
             return await self.channel.exchange_manager.exchange_personal_data.handle_order_update_from_raw(
-                order.order_id, raw_order, should_notify=should_notify)
+                order.order_id, raw_order, should_notify=should_notify, allow_tasks=allow_tasks)
         return False
 
     async def _check_missing_open_orders(self, symbol, orders):

--- a/octobot_trading/channels/orders.py
+++ b/octobot_trading/channels/orders.py
@@ -49,7 +49,7 @@ class OrdersProducer(ExchangeChannelProducer):
                         await self._handle_open_order_update(symbol, order, order_id, is_from_bot, is_new_order)
 
             if not are_closed:
-                await self._handle_post_open_order_update(symbol, orders, has_new_order)
+                await self.handle_post_open_order_update(symbol, orders, has_new_order)
 
         except CancelledError:
             self.logger.info("Update tasks cancelled.")
@@ -81,7 +81,7 @@ class OrdersProducer(ExchangeChannelProducer):
         """
         await self.channel.exchange_manager.exchange_personal_data.handle_closed_order_update(order_id, order)
 
-    async def _handle_post_open_order_update(self, symbol, orders, has_new_order):
+    async def handle_post_open_order_update(self, symbol, orders, has_new_order):
         """
         Perform post open Order update actions :
         - Check if some previously known open order has not been found during update

--- a/octobot_trading/data/order.pxd
+++ b/octobot_trading/data/order.pxd
@@ -71,6 +71,8 @@ cdef class Order(Initializable):
 
     cdef public object exchange_order_type # raw exchange order type, used to create order dict
 
+    cdef object _ensuring_post_update_task
+
     cpdef bint update(self,
             str symbol,
             str order_id=*,

--- a/octobot_trading/data/order.py
+++ b/octobot_trading/data/order.py
@@ -286,7 +286,7 @@ class Order(Initializable):
         result = await self.exchange_manager.exchange.get_order(self.order_id, self.symbol)
         new_status = self.trader.parse_status(result)
         self.is_synchronized_with_exchange = True
-        if new_status is OrderStatus.FILLED:
+        if new_status in {OrderStatus.FILLED, OrderStatus.CLOSED}:
             await self.on_fill()
         elif new_status is OrderStatus.CANCELED:
             await self.trader.cancel_order(self)

--- a/octobot_trading/data/portfolio.pxd
+++ b/octobot_trading/data/portfolio.pxd
@@ -36,7 +36,7 @@ cdef class Portfolio(Initializable):
     cpdef double get_currency_from_given_portfolio(self, str currency, str portfolio_type=*)
     cpdef bint update_portfolio_from_balance(self, dict balance)
     cpdef void update_portfolio_available(self, Order order, bint is_new_order=*)
-    cpdef void update_portfolio_from_order(self, Order order)
+    cpdef void update_portfolio_from_filled_order(self, Order order)
     cpdef void reset_portfolio_available(self, str reset_currency=*, object reset_quantity=*)
     # cpdef dict get_portfolio_from_amount_dict(self, dict amount_dict) can't be cythonized for now
     cpdef void reset(self)

--- a/octobot_trading/data/portfolio.py
+++ b/octobot_trading/data/portfolio.py
@@ -99,7 +99,7 @@ class Portfolio(Initializable):
         """
         return self.get_currency_from_given_portfolio(currency, portfolio_type)
 
-    def update_portfolio_from_order(self, order):
+    def update_portfolio_from_filled_order(self, order):
         """
         update_portfolio performs the update of the total / available quantity of a currency
         It is called only when an order is filled to update the real quantity of the currency to be set in "total" field

--- a/octobot_trading/data/sub_portfolio.py
+++ b/octobot_trading/data/sub_portfolio.py
@@ -52,9 +52,9 @@ class SubPortfolio(Portfolio):
         else:
             self.percent = self.DEFAULT_SUB_PORTFOLIO_PERCENT
 
-    def update_portfolio_from_order(self, order):
-        super().update_portfolio_from_order(order)
-        self.parent_portfolio.update_portfolio_from_order(order)
+    def update_portfolio_from_filled_order(self, order):
+        super().update_portfolio_from_filled_order(order)
+        self.parent_portfolio.update_portfolio_from_filled_order(order)
 
     def update_portfolio_available(self, order, is_new_order=False):
         super().update_portfolio_available(order, is_new_order=is_new_order)

--- a/octobot_trading/data_manager/orders_manager.py
+++ b/octobot_trading/data_manager/orders_manager.py
@@ -53,8 +53,8 @@ class OrdersManager(Initializable):
     async def upsert_order_from_raw(self, order_id, raw_order) -> bool:
         if not self.has_order(order_id):
             new_order = self._create_order_from_raw(raw_order)
-            await new_order.initialize()
             self.orders[order_id] = new_order
+            await new_order.initialize()
             self._check_orders_size()
             return True
         return await _update_order_from_raw(self.orders[order_id], raw_order)

--- a/octobot_trading/data_manager/portfolio_manager.py
+++ b/octobot_trading/data_manager/portfolio_manager.py
@@ -60,7 +60,10 @@ class PortfolioManager(Initializable):
         """
         if self.trader.is_enabled:
             if self.trader.simulate:
-                self.portfolio.update_portfolio_from_order(order)
+                if order.is_filled():
+                    self.portfolio.update_portfolio_from_filled_order(order)
+                else:
+                    self.portfolio.update_portfolio_available(order, is_new_order=False)
                 return True
             else:
                 # on real trading: reload portfolio to ensure portfolio sync

--- a/octobot_trading/exchanges/rest_exchange.py
+++ b/octobot_trading/exchanges/rest_exchange.py
@@ -275,14 +275,15 @@ class RestExchange(AbstractExchange):
     async def cancel_order(self, order_id, symbol=None, params=None):
         if params is None:
             params = {}
+        cancel_resp = None
         try:
-            await self.client.cancel_order(order_id, symbol=symbol, params=params)
+            cancel_resp = await self.client.cancel_order(order_id, symbol=symbol, params=params)
             return parse_is_cancelled(await self.get_order(order_id, symbol=symbol, params=params))
         except OrderNotFound:
             self.logger.error(f"Order {order_id} was not found")
         except Exception as e:
             self.logger.error(f"Order {order_id} failed to cancel | {e}")
-        return False
+        return cancel_resp is not None
 
     async def create_order(self, order_type, symbol, quantity, price=None, stop_price=None, params=None):
         if params is None:

--- a/octobot_trading/orders/order_state.py
+++ b/octobot_trading/orders/order_state.py
@@ -135,7 +135,10 @@ class OrderState(Initializable):
 
     async def on_order_refresh_successful(self):
         """
-        Called when _synchronize_order_with_exchange succeed to update the order
+        Called after a successful update of the order.
+        Warning:
+            - should never be called concurrently in multiple tasks
+            - should never create a task related to order state transitions
         """
         raise NotImplementedError("_on_order_refresh_successful not implemented")
 

--- a/octobot_trading/orders/order_state.py
+++ b/octobot_trading/orders/order_state.py
@@ -151,16 +151,12 @@ class OrderState(Initializable):
         async with self.lock:
             self.state = OrderStates.REFRESHING
         if await self._refresh_order_from_exchange():
-            try:
-                return await self.on_order_refresh_successful()
-            except Exception as e:
-                self.get_logger().warning(f"Error during order synchronization process : {e}, restoring previous...")
-                self.state = previous_state
+            return
         else:
             self.state = previous_state
         if retry_on_fail:
             await self.postpone_synchronization(timeout=retry_timeout)
-        return None
+        return
 
     async def postpone_synchronization(self, timeout=0):
         """

--- a/octobot_trading/orders/states/cancel_order_state.py
+++ b/octobot_trading/orders/states/cancel_order_state.py
@@ -66,8 +66,7 @@ class CancelOrderState(OrderState):
 
             # update portfolio after close
             async with self.order.exchange_manager.exchange_personal_data.get_order_portfolio(self.order).lock:
-                self.order.exchange_manager.exchange_personal_data.get_order_portfolio(self.order) \
-                    .update_portfolio_available(self.order, is_new_order=False)
+                await self.order.exchange_manager.exchange_personal_data.handle_portfolio_update_from_order(self.order)
 
             # set close state
             await self.order.on_close(force_close=True)  # TODO force ?

--- a/octobot_trading/orders/states/open_order_state.py
+++ b/octobot_trading/orders/states/open_order_state.py
@@ -54,6 +54,9 @@ class OpenOrderState(OrderState):
                 # notify order channel than an order has been created even though it's already closed
                 await self.order.exchange_manager.exchange_personal_data.handle_order_update_notification(self.order, True)
 
+            if self.order.status == OrderStatus.CLOSED:
+                self.order.status = OrderStatus.FILLED
+                self.order.state = None
             await create_order_state(self.order, is_from_exchange_data=True)
 
     async def terminate(self):

--- a/octobot_trading/orders/types/limit/limit_order.py
+++ b/octobot_trading/orders/types/limit/limit_order.py
@@ -28,10 +28,6 @@ class LimitOrder(Order):
         self.trigger_above = self.side is TradeOrderSide.SELL
 
     async def update_order_status(self, force_refresh=False):
-        if not self.trader.simulate and not self.is_self_managed() and \
-                (not self.is_synchronized_with_exchange or force_refresh):
-            await self.default_exchange_update_order_status()
-
         if self.limit_price_hit_event is None:
             self.limit_price_hit_event = self.exchange_manager.exchange_symbols_data.\
                 get_exchange_symbol_data(self.symbol).price_events_manager.\

--- a/octobot_trading/orders/types/market/market_order.py
+++ b/octobot_trading/orders/types/market/market_order.py
@@ -20,9 +20,8 @@ from octobot_trading.enums import ExchangeConstantsMarketPropertyColumns
 
 class MarketOrder(Order):
     async def update_order_status(self, force_refresh=False):
-        if not self.trader.simulate and (not self.is_synchronized_with_exchange or force_refresh):
-            await self.default_exchange_update_order_status()
-        await self.on_fill(force_fill=True)
+        if self.trader.simulate:
+            await self.on_fill(force_fill=True)
 
     def on_fill_actions(self):
         self.taker_or_maker = ExchangeConstantsMarketPropertyColumns.TAKER.value

--- a/octobot_trading/producers/orders_updater.py
+++ b/octobot_trading/producers/orders_updater.py
@@ -55,6 +55,8 @@ class OpenOrdersUpdater(OrdersProducer):
             if open_orders:
                 await self.push(orders=list(map(self.channel.exchange_manager.exchange.clean_order, open_orders)),
                                 is_from_bot=is_from_bot)
+            else:
+                await self.handle_post_open_order_update(symbol, open_orders, False)
 
     async def resume(self) -> None:
         await super().resume()

--- a/octobot_trading/traders/trader.py
+++ b/octobot_trading/traders/trader.py
@@ -22,7 +22,7 @@ from octobot_trading.data.order import Order
 from octobot_trading.data.portfolio import Portfolio
 from octobot_trading.enums import OrderStatus, TraderOrderType
 from octobot_trading.orders.order_adapter import check_and_adapt_order_details_if_necessary
-from octobot_trading.orders.order_factory import create_order_instance
+from octobot_trading.orders.order_factory import create_order_instance, create_order_instance_from_raw
 from octobot_trading.orders.order_util import get_pre_order_data
 from octobot_trading.trades.trade_factory import create_trade_from_order
 from octobot_trading.util import is_trader_enabled, get_pairs, get_market_pair
@@ -136,8 +136,7 @@ class Trader(Initializable):
             self.logger.info(f"Created order on {self.exchange_manager.exchange_name}: {created_order}")
 
             # get real order from exchange
-            new_order = Order(self)
-            new_order.update_from_raw(created_order)
+            new_order = create_order_instance_from_raw(self, created_order)
 
             # rebind linked portfolio to new order instance
             new_order.linked_portfolio = portfolio


### PR DESCRIPTION
initial fix proposal: 
- ensure only one task is updating the order state at a time

cons:
- does not fix the actual issue, is a workaround

requires https://github.com/Drakkar-Software/OctoBot-Trading/pull/312