### PR TITLE
use debug instead of warning on missing exchange implem

### DIFF
--- a/octobot_trading/exchanges/util/exchange_util.py
+++ b/octobot_trading/exchanges/util/exchange_util.py
@@ -55,8 +55,7 @@ def search_exchange_class_from_exchange_name(exchange_class, exchange_name,
     if enable_default:
         return None
 
-    logging.get_logger().warning(f"No specific exchange implementation for {exchange_name} "
-                                 f"found, searching for default one...")
+    logging.get_logger().debug(f"No specific exchange implementation for {exchange_name} found, using a default one.")
     return search_exchange_class_from_exchange_name(exchanges_types.SpotExchange, exchange_name,
                                                     tentacles_setup_config, enable_default=True)
 


### PR DESCRIPTION
prevents user worries for something that is not an issue (issues will be displayed with errors if there are any)