### PR TITLE
do not push empty candles list in ohlcv channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.18] - 2020-12-06
+### Fixed
+- Order creation typing issue
+- Updater data issues
+
 ## [1.11.17] - 2020-11-30
 ### Added
 - Exchange load management

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OctoBot-Trading [1.11.17](https://github.com/Drakkar-Software/OctoBot-Trading/blob/master/CHANGELOG.md)
+# OctoBot-Trading [1.11.18](https://github.com/Drakkar-Software/OctoBot-Trading/blob/master/CHANGELOG.md)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/903b6b22bceb4661b608a86fea655f69)](https://app.codacy.com/gh/Drakkar-Software/OctoBot-Trading?utm_source=github.com&utm_medium=referral&utm_content=Drakkar-Software/OctoBot-Trading&utm_campaign=Badge_Grade_Dashboard)
 [![PyPI](https://img.shields.io/pypi/v/OctoBot-Trading.svg)](https://pypi.python.org/pypi/OctoBot-Trading/)
 [![Coverage Status](https://coveralls.io/repos/github/Drakkar-Software/OctoBot-Trading/badge.svg?branch=master)](https://coveralls.io/github/Drakkar-Software/OctoBot-Trading?branch=master)

--- a/octobot_trading/__init__.py
+++ b/octobot_trading/__init__.py
@@ -15,4 +15,4 @@
 #  License along with this library.
 
 PROJECT_NAME = "OctoBot-Trading"
-VERSION = "1.11.17"  # major.minor.revision
+VERSION = "1.11.18"  # major.minor.revision


### PR DESCRIPTION
On not liquid markets, this can happen:
(++++ [[1607260380000, 0.0015418, 0.0015418, 0.0015418, 0.0015418, 0.8199]] is the request result)
![image](https://user-images.githubusercontent.com/9078616/101281663-93f58b00-37d0-11eb-9620-631b243cfcd0.png)
