### PR TITLE
[Version] v1.11.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.25] - 2021-01-26
+### Fixed
+- [CCXT_Exchange] Fix unnecessary 'recvWindows' param
+
 ## [1.11.24] - 2021-01-25
 ### Added
 - [Orders] Orders update event logs

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OctoBot-Trading [1.11.24](https://github.com/Drakkar-Software/OctoBot-Trading/blob/master/CHANGELOG.md)
+# OctoBot-Trading [1.11.25](https://github.com/Drakkar-Software/OctoBot-Trading/blob/master/CHANGELOG.md)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/903b6b22bceb4661b608a86fea655f69)](https://app.codacy.com/gh/Drakkar-Software/OctoBot-Trading?utm_source=github.com&utm_medium=referral&utm_content=Drakkar-Software/OctoBot-Trading&utm_campaign=Badge_Grade_Dashboard)
 [![PyPI](https://img.shields.io/pypi/v/OctoBot-Trading.svg)](https://pypi.python.org/pypi/OctoBot-Trading/)
 [![Coverage Status](https://coveralls.io/repos/github/Drakkar-Software/OctoBot-Trading/badge.svg?branch=master)](https://coveralls.io/github/Drakkar-Software/OctoBot-Trading?branch=master)

--- a/octobot_trading/__init__.py
+++ b/octobot_trading/__init__.py
@@ -15,4 +15,4 @@
 #  License along with this library.
 
 PROJECT_NAME = "OctoBot-Trading"
-VERSION = "1.11.24"  # major.minor.revision
+VERSION = "1.11.25"  # major.minor.revision

--- a/octobot_trading/exchanges/connectors/ccxt_exchange.py
+++ b/octobot_trading/exchanges/connectors/ccxt_exchange.py
@@ -157,7 +157,7 @@ class CCXTExchange(abstract_exchange.AbstractExchange):
         :return: balance dict
         """
         if not kwargs:
-            kwargs = {'recvWindow': 10000000}
+            kwargs = {}
         try:
             balance = await self.client.fetch_balance(params=kwargs)
 


### PR DESCRIPTION
A bug is currently impacting all real get_balances. Only binance is supporting 'recvWindows' param when requesting balance. Other exchanges like Kraken and Bittrex (reported on telegram channel, thanks @makisasartakis) fail to get user balance. An example is Bittrex current response to get_balance :
```json
{"code":"BAD_REQUEST","detail":"Refer to the data field for specific field validation failures.","data":{"invalidRequestParameter":"recvWindow"}}
```

The fix consists to remove the unnecessary 'recvWindow' for each exchange and let the exchange tentacle adding this param if necessary (like binance tentacle is currently doing).

## [1.11.25] - 2021-01-26
### Fixed
- [CCXT_Exchange] Fix unnecessary 'recvWindows' param