### PR TITLE
[Orders] do not try to compute fees when missing exchange_manager

### DIFF
--- a/octobot_trading/personal_data/orders/states/fill_order_state.py
+++ b/octobot_trading/personal_data/orders/states/fill_order_state.py
@@ -82,7 +82,8 @@ class FillOrderState(order_state.OrderState):
 
             # compute trading fees
             try:
-                self.order.fee = self.order.get_computed_fee()
+                if self.order.exchange_manager is not None:
+                    self.order.fee = self.order.get_computed_fee()
             except KeyError:
                 self.get_logger().error(f"Fail to compute trading fees for {self.order}.")
 


### PR DESCRIPTION
the issue:
```
2021-02-28 21:10:09 DEBUG  BalanceProducer[binance] events.py:81       Refreshing portfolio from binance exchange
2021-02-28 21:10:09 INFO   OctoBot Channel      logger.py:317      ORDERS : EXCHANGE = binance || SYMBOL = BTC/BUSD || SELL LIMIT: 0.01 BTC at 45351 BUSD on Binance || status = closed || CREATED = False || FROM_BOT = True
2021-02-28 21:10:09 INFO   OctoBot Channel      logger.py:297      TRADES : EXCHANGE = binance || CRYPTOCURRENCY = BTC || SYMBOL = BTC/BUSD || TRADE = {'id': '1864282621', 'symbol': 'BTC/BUSD', 'price': 45351.0, 'status': 'closed', 'timestamp': 1614546555.233, 'type': 'limit', 'side': 'sell', 'amount': 0.01, 'cost': 453.51, 'takerOrMaker': 'maker', 'fee': {'cost': 0.0, 'currency': 'BNB'}} || OLD_TRADE = False
2021-02-28 21:10:09 ERROR  root                 logger.py:44       
NoneType: None
2021-02-28 21:10:09 ERROR  root                 logger.py:45       <class 'AttributeError'>: 'NoneType' object has no attribute 'exchange_name'
NoneType: None
2021-02-28 21:10:09 ERROR  root                 logger.py:44       
NoneType: None
2021-02-28 21:10:09 ERROR  root                 logger.py:45       <class 'AttributeError'>: 'NoneType' object has no attribute 'exchange'
NoneType: None
2021-02-28 21:10:09 ERROR  SellLimitOrder | 1864282621 events.py:81       'NoneType' object has no attribute 'exchange'
Traceback (most recent call last):
  File "octobot_trading/personal_data/orders/states/fill_order_state.py", line 85, in octobot_trading.personal_data.orders.states.fill_order_state.FillOrderState.terminate
  File "octobot_trading/personal_data/orders/order.py", line 266, in octobot_trading.personal_data.orders.order.Order.get_computed_fee
  File "octobot_trading/personal_data/orders/order.py", line 267, in octobot_trading.personal_data.orders.order.Order.get_computed_fee
AttributeError: 'NoneType' object has no attribute 'exchange'
2021-02-28 21:10:09 ERROR  SellLimitOrder | 1864282621 events.py:81       Fail to execute fill state termination : 'NoneType' object has no attribute 'exchange'. (AttributeError)
2021-02-28 21:10:09 WARNING TaskManager          task_manager.py:98       Error in bot main async loop: {'message': 'Task exception was never retrieved', 'exception': AttributeError("'NoneType' object has no attribute 'exchange'"), 'future': <Task finished name='Task-105058' coro=<<coroutine without name>()> exception=AttributeError("'NoneType' object has no attribute 'exchange'")>}
```