### PR TITLE
Restore order adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.4] - 2021-04-07 
+### Fixed
+- string formatting in float order adapter
+
 ## [1.12.3] - 2021-04-06 
 ### Added
 - decimal.Decimal handling

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OctoBot-Trading [1.12.3](https://github.com/Drakkar-Software/OctoBot-Trading/blob/master/CHANGELOG.md)
+# OctoBot-Trading [1.12.4](https://github.com/Drakkar-Software/OctoBot-Trading/blob/master/CHANGELOG.md)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/903b6b22bceb4661b608a86fea655f69)](https://app.codacy.com/gh/Drakkar-Software/OctoBot-Trading?utm_source=github.com&utm_medium=referral&utm_content=Drakkar-Software/OctoBot-Trading&utm_campaign=Badge_Grade_Dashboard)
 [![PyPI](https://img.shields.io/pypi/v/OctoBot-Trading.svg)](https://pypi.python.org/pypi/OctoBot-Trading/)
 [![Coverage Status](https://coveralls.io/repos/github/Drakkar-Software/OctoBot-Trading/badge.svg?branch=master)](https://coveralls.io/github/Drakkar-Software/OctoBot-Trading?branch=master)

--- a/octobot_trading/__init__.py
+++ b/octobot_trading/__init__.py
@@ -15,4 +15,4 @@
 #  License along with this library.
 
 PROJECT_NAME = "OctoBot-Trading"
-VERSION = "1.12.3"  # major.minor.revision
+VERSION = "1.12.4"  # major.minor.revision

--- a/octobot_trading/personal_data/orders/order_adapter.py
+++ b/octobot_trading/personal_data/orders/order_adapter.py
@@ -14,7 +14,6 @@
 #  You should have received a copy of the GNU Lesser General Public
 #  License along with this library.
 import math
-import decimal
 
 import octobot_trading.constants as constants
 import octobot_trading.exchanges as exchanges
@@ -36,15 +35,9 @@ def adapt_quantity(symbol_market, quantity):
 
 def trunc_with_n_decimal_digits(value, digits):  # TODO migrate to commons
     try:
-        # decimal.Decimal can add unnecessary complexity in numbers, only use it when necessary
-        if len(str(value).split(".")[-1]) > digits:
-            if digits > 0:
-                return float(decimal.Decimal(value).quantize(decimal.Decimal(f".{'0' * digits}"),
-                                                             rounding=decimal.ROUND_DOWN))
-            else:
-                return math.floor(value)
-        return value
-    except (ValueError, decimal.InvalidOperation):
+        # force exact representation
+        return float("{0:.{1}f}".format(math.trunc(value * 10 ** digits) / (10 ** digits), digits if digits > 1 else 1))
+    except ValueError:
         return value
 
 

--- a/tests/personal_data/orders/test_order_adapter.py
+++ b/tests/personal_data/orders/test_order_adapter.py
@@ -38,7 +38,7 @@ async def test_adapt_price():
     # will use default (CURRENCY_DEFAULT_MAX_PRICE_DIGITS)
     symbol_market = {Ecmsc.PRECISION.value: {}}
     assert personal_data.adapt_price(symbol_market, 0.0001) == 0.0001
-    assert personal_data.adapt_price(symbol_market, 0.00015) == 0.00015
+    assert personal_data.adapt_price(symbol_market, 0.00015) == 0.00014999
     assert personal_data.adapt_price(symbol_market, 0.005) == 0.005
     assert personal_data.adapt_price(symbol_market, 1) == 1.0000000000000000000000001
     assert personal_data.adapt_price(symbol_market, 1) == 1


### PR DESCRIPTION
restore previous float trunc method to prevent edge cases side effects when using float inputs.
No change for decimal_order_adapter