### PR TITLE
[FuturePortfolio] ensure portfolio is updated in one statement

### DIFF
--- a/octobot_trading/personal_data/portfolios/types/future_portfolio.py
+++ b/octobot_trading/personal_data/portfolios/types/future_portfolio.py
@@ -128,12 +128,14 @@ class FuturePortfolio(portfolio_class.Portfolio):
                 update_quantity = liquidated_quantity / position.mark_price
                 self._update_future_portfolio_data(position.currency,
                                                    position_margin_value=update_quantity,
-                                                   wallet_value=update_quantity)
+                                                   wallet_value=update_quantity,
+                                                   unrealized_pnl_value=-position.unrealised_pnl)
             else:
                 update_quantity = liquidated_quantity * position.mark_price
                 self._update_future_portfolio_data(position.market,
                                                    position_margin_value=update_quantity,
-                                                   wallet_value=update_quantity)
+                                                   wallet_value=update_quantity,
+                                                   unrealized_pnl_value=-position.unrealised_pnl)
         except (decimal.DivisionByZero, decimal.InvalidOperation) as e:
             self.logger.error(f"Failed to update from liquidated position : {position} ({e})")
 

--- a/octobot_trading/personal_data/positions/position.py
+++ b/octobot_trading/personal_data/positions/position.py
@@ -280,8 +280,10 @@ class Position(util.Initializable):
         # set position entry price if necessary
         self._update_prices_if_necessary(order.filled_price)
 
-        # Updates position average entry price from order
-        self.update_average_entry_price(size_update, order.filled_price)
+        if self._is_update_increasing_size(size_update):
+            # Updates position average entry price from order
+            # Only when increasing position side
+            self.update_average_entry_price(size_update, order.filled_price)
 
         # update size and realised pnl
         has_increase_position_size = self._update_size(size_update, order)

--- a/octobot_trading/personal_data/positions/position.py
+++ b/octobot_trading/personal_data/positions/position.py
@@ -200,7 +200,7 @@ class Position(util.Initializable):
         if mark_price is not None:
             self._update_mark_price(mark_price)
         if update_margin is not None:
-            self._update_size_from_margin(update_margin)
+            self.update_size_from_margin(update_margin)
         if update_size is not None:
             self._update_size(update_size)
 
@@ -230,13 +230,13 @@ class Position(util.Initializable):
         if self.entry_price == constants.ZERO:
             self.entry_price = mark_price
 
-    def _update_size_from_margin(self, margin_update):
+    def update_size_from_margin(self, margin_update, update_order_margin=False):
         """
         Updates position size and margin by converting margin to size and calling self._update_size
         :param margin_update: the position margin update
         """
         try:
-            self._update_size(self.get_size_from_margin(margin_update))
+            self._update_size(self.get_size_from_margin(margin_update), update_order_margin=update_order_margin)
         except (decimal.DivisionByZero, decimal.InvalidOperation):
             pass
 
@@ -260,6 +260,9 @@ class Position(util.Initializable):
         :param order: the filled order instance
         :return: the updated quantity, True if the order increased position size
         """
+        # consider the order filled price as the current reference price for pnl computation
+        self._update_mark_price(order.filled_price)
+
         size_to_close = self.get_quantity_to_close()
 
         # Remove / add order fees from realized pnl
@@ -268,7 +271,7 @@ class Position(util.Initializable):
         # Close position if order is closing position
         if order.close_position:
             # set position size to 0 to schedule position close at the next update
-            self._update_size(-self.size if self.is_long() else self.size)
+            self._update_size(-self.size if self.is_long() else self.size, order)
             return size_to_close, False
 
         # Calculates position quantity update from order
@@ -281,7 +284,7 @@ class Position(util.Initializable):
         self.update_average_entry_price(size_update, order.filled_price)
 
         # update size and realised pnl
-        has_increase_position_size = self._update_size(size_update)
+        has_increase_position_size = self._update_size(size_update, order)
         return size_update, has_increase_position_size
 
     def _update_realized_pnl_from_order(self, order):
@@ -325,6 +328,17 @@ class Position(util.Initializable):
             return size_update > constants.ZERO
         return size_update < constants.ZERO
 
+    def _is_update_decreasing_size(self, size_update):
+        """
+        :param size_update: the size update
+        :return: True if this update will increase position size
+        """
+        if self.is_idle():
+            return False
+        if self.is_long():
+            return size_update < constants.ZERO
+        return size_update > constants.ZERO
+
     def _is_update_closing(self, size_update):
         """
         :param size_update: the size update
@@ -336,27 +350,42 @@ class Position(util.Initializable):
             return self.size + size_update <= constants.ZERO
         return self.size + size_update >= constants.ZERO
 
-    def _update_size(self, update_size):
+    def _update_size(self, size_update, closed_order=None, update_order_margin=False):
         """
         Updates position size and triggers size related attributes update
-        :param update_size: the size quantity
+        :param size_update: the size quantity
         :return: True if the update increased position size
         """
-        is_update_increasing_position_size = self._is_update_increasing_size(update_size)
-        if not is_update_increasing_position_size:
-            self._update_realized_pnl_from_size_update(update_size, is_closing=self._is_update_closing(update_size))
-        self._check_and_update_size(update_size)
+        order_price = constants.ZERO if closed_order is None else closed_order.filled_price
+        is_increasing_size = self._is_update_increasing_size(size_update)
+        realized_pnl_update = constants.ZERO
+        if self._is_update_decreasing_size(size_update):
+            realized_pnl_update = self._update_realized_pnl_from_size_update(
+                size_update,
+                is_closing=self._is_update_closing(size_update),
+                order_price=order_price
+            )
+            # TODO check: funding fees when no wallet balance: as they reduce the size of the position, the final
+            # realized pnl will be smaller, it should therefore be taken into account.
+        self._check_and_update_size(size_update)
         self._update_quantity()
         self._update_side()
         if self.exchange_manager.is_simulated:
-            self._update_initial_margin()
+            margin_update = self._update_initial_margin()
+            if closed_order is None:
+                self.on_margin_update(margin_update, update_order_margin=update_order_margin)
+            else:
+                # TODO: check if needed in real trader ?
+                self.on_closed_order_update(closed_order, realized_pnl_update, size_update, margin_update,
+                                            is_increasing_size)
             self.update_fee_to_close()
             self.update_liquidation_price()
             self.update_value()
             self.update_pnl()
-        return is_update_increasing_position_size
+        return is_increasing_size
 
-    def _update_realized_pnl_from_size_update(self, size_update, is_closing=False):
+    def _update_realized_pnl_from_size_update(self, size_update, is_closing=False,
+                                              order_price=constants.ZERO):
         """
         Updates the position realized pnl from update size
         :param size_update: the position update size
@@ -369,10 +398,10 @@ class Position(util.Initializable):
                                                                 self.symbol,
                                                                 realised_pnl=realised_pnl_update,
                                                                 is_closed_pnl=is_closing)
-            self.on_pnl_update(realised_pnl_update=realised_pnl_update)
         except (decimal.DivisionByZero, decimal.InvalidOperation):
             realised_pnl_update = constants.ZERO
         self.realised_pnl += realised_pnl_update
+        return realised_pnl_update
 
     def _check_and_update_size(self, size_update):
         """
@@ -425,7 +454,7 @@ class Position(util.Initializable):
             previous_initial_margin = self.initial_margin
             self.initial_margin = self.get_margin_from_size(self.size).copy_abs()
             self._update_margin()
-            self.on_margin_update(self.initial_margin - previous_initial_margin)
+            return self.initial_margin - previous_initial_margin
         except (decimal.DivisionByZero, decimal.InvalidOperation):
             self.initial_margin = constants.ZERO
 
@@ -558,13 +587,23 @@ class Position(util.Initializable):
         self.exchange_manager.exchange_personal_data.portfolio_manager.portfolio.\
             update_portfolio_from_pnl(self, realised_pnl_update)
 
-    def on_margin_update(self, margin_update=constants.ZERO):
+    def on_closed_order_update(self, order, realized_pnl_update, size_update, margin_update,
+                               has_increased_position_size):
         """
         Called when position margin has been updated
         :param margin_update: the margin update value
         """
         self.exchange_manager.exchange_personal_data.portfolio_manager.portfolio.\
-            update_portfolio_from_margin(self, margin_update)
+            update_portfolio_data_from_closed_order(self, order, realized_pnl_update, size_update, margin_update,
+                                                    has_increased_position_size)
+
+    def on_margin_update(self, margin_update=constants.ZERO, update_order_margin=False):
+        """
+        Called when position margin has been updated
+        :param margin_update: the margin update value
+        """
+        self.exchange_manager.exchange_personal_data.portfolio_manager.portfolio.\
+            update_portfolio_from_margin(self, margin_update, margin_update if update_order_margin else constants.ZERO)
 
     async def recreate(self):
         """

--- a/tests/personal_data/positions/types/test_linear_position.py
+++ b/tests/personal_data/positions/types/test_linear_position.py
@@ -21,6 +21,7 @@ import pytest
 import octobot_trading.constants as constants
 import octobot_trading.personal_data as personal_data
 import octobot_trading.enums as enums
+import octobot_trading.errors as errors
 
 from tests import event_loop
 from tests.exchanges import future_simulated_exchange_manager
@@ -30,6 +31,12 @@ from tests.test_utils.random_numbers import decimal_random_price, decimal_random
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
+
+
+FORTY = decimal.Decimal(40)
+TWENTY_FOUR = decimal.Decimal(24)
+TWENTY_FIVE = decimal.Decimal(25)
+TWELVE_DOT_FIVE = decimal.Decimal('12.5')
 
 
 async def test_update_value(future_trader_simulator_with_default_linear):
@@ -50,61 +57,209 @@ async def test_update_pnl_with_long_linear_position(future_trader_simulator_with
     config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
     position_inst = personal_data.LinearPosition(trader_inst, default_contract)
     position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
-    position_inst.entry_price = constants.ONE_HUNDRED
-    await position_inst.update(update_size=constants.ONE_HUNDRED, mark_price=constants.ONE_HUNDRED)
+
+    # open long of 24 contracts at 40 usdt
+    await position_inst.update(update_size=TWENTY_FOUR, mark_price=FORTY)
     position_inst.update_pnl()
     assert position_inst.unrealised_pnl == constants.ZERO
-    await position_inst.update(update_size=constants.ONE_HUNDRED,
-                               mark_price=decimal.Decimal(2) * constants.ONE_HUNDRED)
+    # add long of 1 contract at 80 usdt
+    await position_inst.update(update_size=constants.ONE,
+                               mark_price=decimal.Decimal(3) * FORTY)
     position_inst.update_pnl()
-    assert position_inst.unrealised_pnl == decimal.Decimal("20000")
+    # now have 25 contracts each now worth 120 usdt => 2000 in profit
+    assert position_inst.unrealised_pnl == decimal.Decimal("2000")
 
 
 async def test_update_pnl_with_short_linear_position(future_trader_simulator_with_default_linear):
     config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
     position_inst = personal_data.LinearPosition(trader_inst, default_contract)
     position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
-    position_inst.entry_price = constants.ONE_HUNDRED
-    await position_inst.update(update_size=-constants.ONE_HUNDRED, mark_price=constants.ONE_HUNDRED)
+
+    # open short of 24 contracts at 40 usdt
+    await position_inst.update(update_size=-TWENTY_FOUR, mark_price=FORTY)
     position_inst.update_pnl()
     assert position_inst.unrealised_pnl == constants.ZERO
-    await position_inst.update(update_size=-constants.ONE_HUNDRED,
-                               mark_price=constants.ONE_HUNDRED / decimal.Decimal(10))
+    # add short of 1 contract at 4 usdt
+    await position_inst.update(update_size=-constants.ONE,
+                               mark_price=FORTY / decimal.Decimal(10))
     position_inst.update_pnl()
-    assert position_inst.unrealised_pnl == decimal.Decimal("18000")
+    # now have 25 contracts each now worth 36 usdt (40 entry - 4 now) => 25 * 36 = 900 in profit
+    assert position_inst.unrealised_pnl == decimal.Decimal("900")
 
 
-async def test_update_pnl_with_loss_with_long_linear_position(future_trader_simulator_with_default_linear):
-    config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
-
-    position_inst = personal_data.LinearPosition(trader_inst, default_contract)
-    position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
-    position_inst.entry_price = constants.ONE_HUNDRED
-    await position_inst.update(update_size=constants.ONE_HUNDRED, mark_price=constants.ONE_HUNDRED)
-    position_inst.update_pnl()
-    assert position_inst.unrealised_pnl == constants.ZERO
-    exchange_manager_inst.exchange_personal_data.portfolio_manager.portfolio.get_currency_portfolio(
-        "USDT").wallet_balance = decimal.Decimal(100000)  # TO prevent portfolio negative error
-    await position_inst.update(update_size=constants.ONE_HUNDRED,
-                               mark_price=constants.ONE_HUNDRED / decimal.Decimal(2.535485))
-    position_inst.update_pnl()
-    assert position_inst.unrealised_pnl == decimal.Decimal("-12111.96280001656484319345490")
-
-
-async def test_update_pnl_with_loss_with_short(future_trader_simulator_with_default_linear):
+async def test_update_pnl_with_loss_with_long_linear_position_inc_position(future_trader_simulator_with_default_linear):
     config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
     position_inst = personal_data.LinearPosition(trader_inst, default_contract)
     position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
-    position_inst.entry_price = constants.ONE_HUNDRED
-    await position_inst.update(update_size=-constants.ONE_HUNDRED, mark_price=constants.ONE_HUNDRED)
+
+    # open long of 24 contracts at 40 usdt
+    await position_inst.update(update_size=TWENTY_FOUR, mark_price=FORTY)
     position_inst.update_pnl()
     assert position_inst.unrealised_pnl == constants.ZERO
-    exchange_manager_inst.exchange_personal_data.portfolio_manager.portfolio.get_currency_portfolio(
-        "USDT").wallet_balance = decimal.Decimal(100000)  # TO prevent portfolio negative error
-    await position_inst.update(update_size=-constants.ONE_HUNDRED,
-                               mark_price=constants.ONE_HUNDRED * decimal.Decimal(1.0954))
+    # add long of 1 contract at 40 / 2.535485
+    await position_inst.update(update_size=constants.ONE,
+                               mark_price=FORTY / decimal.Decimal("2.535485"))
     position_inst.update_pnl()
-    assert position_inst.unrealised_pnl == decimal.Decimal("-1907.999999999998586019955840")
+    # now have 25 contracts each now worth 15.7760744 (40/2.535485) usdt => 25 * 40 - 25 * 15.7760744 in loss
+    assert position_inst.unrealised_pnl == decimal.Decimal("-605.5981400008282439059982608")
+
+
+async def test_update_pnl_with_loss_with_long_linear_position_red_position(future_trader_simulator_with_default_linear):
+    config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
+    position_inst = personal_data.LinearPosition(trader_inst, default_contract)
+    position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
+
+    # open long of 24 contracts at 40 usdt
+    await position_inst.update(update_size=TWENTY_FOUR, mark_price=FORTY)
+    position_inst.update_pnl()
+    assert position_inst.unrealised_pnl == constants.ZERO
+    # reduce long of 1 contract at 40 / 2.535485
+    await position_inst.update(update_size=-constants.ONE,
+                               mark_price=FORTY / decimal.Decimal("2.535485"))
+    position_inst.update_pnl()
+    # now have 23 contracts each now worth 15.7760744 (40/2.535485) usdt => 23 * 40 - 23 * 15.7760744 in loss
+    assert position_inst.unrealised_pnl == decimal.Decimal("-557.1502888007619843935183999")
+
+
+async def test_update_pnl_with_loss_with_short_inc_position(future_trader_simulator_with_default_linear):
+    config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
+    position_inst = personal_data.LinearPosition(trader_inst, default_contract)
+    position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
+
+    # open short of 24 contracts at 40 usdt
+    await position_inst.update(update_size=-TWENTY_FOUR, mark_price=FORTY)
+    position_inst.update_pnl()
+    assert position_inst.unrealised_pnl == constants.ZERO
+    # add short of 1 contract at 40 * 1.0954
+    await position_inst.update(update_size=-constants.ONE,
+                               mark_price=FORTY * decimal.Decimal("1.0954"))
+    position_inst.update_pnl()
+    # now have 25 contracts each now worth 43.816 (40 * 1.0954) usdt => 25 * 40 - 25 * 43.816 in loss
+    assert position_inst.unrealised_pnl == decimal.Decimal("-95.4")
+
+
+async def test_update_pnl_with_loss_with_short_red_position(future_trader_simulator_with_default_linear):
+    config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
+    position_inst = personal_data.LinearPosition(trader_inst, default_contract)
+    position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
+
+    # open short of 24 contracts at 40 usdt
+    await position_inst.update(update_size=-TWENTY_FOUR, mark_price=FORTY)
+    position_inst.update_pnl()
+    assert position_inst.unrealised_pnl == constants.ZERO
+    # reduce short of 1 contract at 40 * 1.0954
+    await position_inst.update(update_size=constants.ONE,
+                               mark_price=FORTY * decimal.Decimal("1.0954"))
+    position_inst.update_pnl()
+    # now have 23 contracts each now worth 43.816 (40 * 1.0954) usdt => 23 * 40 - 23 * 43.816 in loss
+    assert position_inst.unrealised_pnl == decimal.Decimal("-87.768")
+
+
+async def test_update_pnl_with_loss_with_too_big_positions(future_trader_simulator_with_default_linear):
+    config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
+    position_inst = personal_data.LinearPosition(trader_inst, default_contract)
+    position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
+    portfolio = exchange_manager_inst.exchange_personal_data.portfolio_manager.portfolio
+
+    # open long of 100 contracts at 40 usdt: not enough funds
+    with pytest.raises(errors.PortfolioNegativeValueError):
+        await position_inst.update(update_size=constants.ONE_HUNDRED, mark_price=FORTY)
+    assert position_inst.unrealised_pnl == constants.ZERO
+    assert position_inst.realised_pnl == constants.ZERO
+    assert position_inst.initial_margin == constants.ZERO
+    assert portfolio.get_currency_portfolio("USDT").position_margin == constants.ZERO
+    assert portfolio.get_currency_portfolio("USDT").available == decimal.Decimal('1000')
+    assert portfolio.get_currency_portfolio("USDT").total == decimal.Decimal('1000')
+
+    # open short of 100 contracts at 40 usdt: not enough funds
+    # TODO not working because FutureAsset#update uses self.position_margin = self._ensure_not_negative
+    # which cancels the negative margin here and prevents raising on available amount update, is that normal ?
+    with pytest.raises(errors.PortfolioNegativeValueError):
+        await position_inst.update(update_size=-constants.ONE_HUNDRED, mark_price=FORTY)
+    assert position_inst.unrealised_pnl == constants.ZERO
+    assert position_inst.realised_pnl == constants.ZERO
+    assert position_inst.initial_margin == constants.ZERO
+    assert portfolio.get_currency_portfolio("USDT").position_margin == constants.ZERO
+    assert portfolio.get_currency_portfolio("USDT").available == decimal.Decimal('1000')
+    assert portfolio.get_currency_portfolio("USDT").total == decimal.Decimal('1000')
+
+
+async def test_update_pnl_with_loss_with_full_long_position(future_trader_simulator_with_default_linear):
+    config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
+    position_inst = personal_data.LinearPosition(trader_inst, default_contract)
+    position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
+    portfolio = exchange_manager_inst.exchange_personal_data.portfolio_manager.portfolio
+
+    # open long of 25 contracts at 40 usdt
+    await position_inst.update(update_size=TWENTY_FIVE, mark_price=FORTY)
+    assert position_inst.unrealised_pnl == constants.ZERO
+    assert position_inst.realised_pnl == constants.ZERO
+    assert portfolio.get_currency_portfolio("USDT").position_margin == decimal.Decimal('1000')
+    assert portfolio.get_currency_portfolio("USDT").available == constants.ZERO
+    assert portfolio.get_currency_portfolio("USDT").total == decimal.Decimal('1000')
+
+    # reduce short of 1 contract at 40 * 1.0954
+    await position_inst.update(update_size=-constants.ONE,
+                               mark_price=FORTY * decimal.Decimal("1.0954"))
+
+    # now have 24 contracts each now worth 43.816 (40 * 1.0954) usdt => 40 - 43.816 in profit per contract
+    assert position_inst.unrealised_pnl == decimal.Decimal("91.584")
+    assert position_inst.realised_pnl == decimal.Decimal("3.816")
+    assert portfolio.get_currency_portfolio("USDT").position_margin == decimal.Decimal('960')
+    assert portfolio.get_currency_portfolio("USDT").available == decimal.Decimal('40')
+    assert portfolio.get_currency_portfolio("USDT").total == decimal.Decimal('1091.584')
+
+    # reduce short of 24 contract at 40 - 2
+    await position_inst.update(update_size=-TWENTY_FOUR,
+                               mark_price=FORTY - decimal.Decimal(2))
+    # now have 24 contracts each now worth 38 (40 - 2) usdt => 40 - 38 in loss per contract
+    # position got reset
+    assert position_inst.unrealised_pnl == constants.ZERO
+    assert position_inst.realised_pnl == constants.ZERO
+    # no closing order: portfolio margin got updated and funds settled but not realized pnl is applied
+    # as there is not closing order => reset funds to 1000
+    assert portfolio.get_currency_portfolio("USDT").position_margin == constants.ZERO
+    assert portfolio.get_currency_portfolio("USDT").available == decimal.Decimal('1000')
+    assert portfolio.get_currency_portfolio("USDT").total == decimal.Decimal('1000')
+
+
+async def test_update_pnl_with_loss_with_full_short_position(future_trader_simulator_with_default_linear):
+    config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
+    position_inst = personal_data.LinearPosition(trader_inst, default_contract)
+    position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
+    portfolio = exchange_manager_inst.exchange_personal_data.portfolio_manager.portfolio
+
+    # open short of 25 contracts at 40 usdt
+    await position_inst.update(update_size=-TWENTY_FIVE, mark_price=FORTY)
+    assert position_inst.unrealised_pnl == constants.ZERO
+    assert position_inst.realised_pnl == constants.ZERO
+    assert portfolio.get_currency_portfolio("USDT").position_margin == decimal.Decimal('1000')
+    assert portfolio.get_currency_portfolio("USDT").available == constants.ZERO
+    assert portfolio.get_currency_portfolio("USDT").total == decimal.Decimal('1000')
+
+    # reduce short of 1 contract at 40 * 1.0954
+    await position_inst.update(update_size=constants.ONE,
+                               mark_price=FORTY * decimal.Decimal("1.0954"))
+
+    # now have 24 contracts each now worth 43.816 (40 * 1.0954) usdt => 40 - 43.816 in loss per contract
+    assert position_inst.unrealised_pnl == decimal.Decimal("-91.584")
+    assert position_inst.realised_pnl == decimal.Decimal("-3.816")
+    assert portfolio.get_currency_portfolio("USDT").position_margin == decimal.Decimal('960')
+    assert portfolio.get_currency_portfolio("USDT").available == decimal.Decimal('40')
+    assert portfolio.get_currency_portfolio("USDT").total == decimal.Decimal('908.4160')
+
+    # reduce short of 24 contract at 40 - 2
+    await position_inst.update(update_size=TWENTY_FOUR,
+                               mark_price=FORTY - decimal.Decimal(2))
+    # now have 24 contracts each now worth 38 (40 - 2) usdt => 40 - 38 in profit per contract
+    # position got reset
+    assert position_inst.unrealised_pnl == constants.ZERO
+    assert position_inst.realised_pnl == constants.ZERO
+    # no closing order: portfolio margin got updated and funds settled but not realized pnl is applied
+    # as there is not closing order => reset funds to 1000
+    assert portfolio.get_currency_portfolio("USDT").position_margin == constants.ZERO
+    assert portfolio.get_currency_portfolio("USDT").available == decimal.Decimal('1000')
+    assert portfolio.get_currency_portfolio("USDT").total == decimal.Decimal('1000')
 
 
 async def test_update_initial_margin(future_trader_simulator_with_default_linear):
@@ -116,75 +271,75 @@ async def test_update_initial_margin(future_trader_simulator_with_default_linear
         await position_inst.update(update_size=constants.ZERO, mark_price=constants.ZERO)
         position_inst._update_initial_margin()
         assert position_inst.initial_margin == constants.ZERO
-        await position_inst.update(update_size=constants.ONE_HUNDRED, mark_price=constants.ONE_HUNDRED)
+        await position_inst.update(update_size=TWENTY_FIVE, mark_price=FORTY)
         position_inst._update_initial_margin()
-        assert position_inst.initial_margin == decimal.Decimal("10000")
+        assert position_inst.initial_margin == decimal.Decimal("1000")
         default_contract.set_current_leverage(constants.ONE_HUNDRED)
         position_inst._update_initial_margin()
-        assert position_inst.initial_margin == decimal.Decimal("100")
+        assert position_inst.initial_margin == decimal.Decimal("10")
 
 
 async def test_get_margin_from_size(future_trader_simulator_with_default_linear):
     config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
     position_inst = personal_data.LinearPosition(trader_inst, default_contract)
+    position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
 
-    await position_inst.update(update_size=constants.ONE_HUNDRED, mark_price=constants.ONE_HUNDRED)
-    assert position_inst.get_margin_from_size(constants.ONE) == decimal.Decimal('100')
+    await position_inst.update(update_size=TWENTY_FIVE, mark_price=FORTY)
+    assert position_inst.get_margin_from_size(constants.ONE) == decimal.Decimal('40')
     default_contract.set_current_leverage(constants.ONE_HUNDRED)
-    assert position_inst.get_margin_from_size(constants.ONE) == constants.ONE
+    assert position_inst.get_margin_from_size(constants.ONE) == decimal.Decimal('0.4')
     default_contract.set_current_leverage(constants.ONE)
-    assert position_inst.get_margin_from_size(decimal.Decimal('0.01')) == constants.ONE
-    assert position_inst.get_margin_from_size(decimal.Decimal('0.1')) == decimal.Decimal('10')
-    assert position_inst.get_margin_from_size(decimal.Decimal('1')) == decimal.Decimal('100')
+    assert position_inst.get_margin_from_size(decimal.Decimal('0.01')) == decimal.Decimal('0.4')
+    assert position_inst.get_margin_from_size(decimal.Decimal('0.1')) == decimal.Decimal('4')
+    assert position_inst.get_margin_from_size(decimal.Decimal('1')) == decimal.Decimal('40')
 
 
 async def test_get_size_from_margin(future_trader_simulator_with_default_linear):
     config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
     position_inst = personal_data.LinearPosition(trader_inst, default_contract)
+    position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
 
-    await position_inst.update(update_size=constants.ONE_HUNDRED, mark_price=constants.ONE_HUNDRED)
-    assert position_inst.get_size_from_margin(constants.ONE) == decimal.Decimal('0.01')
+    await position_inst.update(update_size=TWENTY_FIVE, mark_price=FORTY)
+    assert position_inst.get_size_from_margin(constants.ONE) == decimal.Decimal('0.025')
     default_contract.set_current_leverage(constants.ONE_HUNDRED)
-    assert position_inst.get_size_from_margin(constants.ONE) == constants.ONE
+    assert position_inst.get_size_from_margin(constants.ONE) == decimal.Decimal('2.5')
     default_contract.set_current_leverage(constants.ONE)
-    assert position_inst.get_size_from_margin(decimal.Decimal('0.01')) == decimal.Decimal('0.0001')
-    assert position_inst.get_size_from_margin(decimal.Decimal('0.1')) == decimal.Decimal('0.001')
-    assert position_inst.get_size_from_margin(decimal.Decimal('1')) == decimal.Decimal('0.01')
+    assert position_inst.get_size_from_margin(decimal.Decimal('0.01')) == decimal.Decimal('0.00025')
+    assert position_inst.get_size_from_margin(decimal.Decimal('0.1')) == decimal.Decimal('0.0025')
+    assert position_inst.get_size_from_margin(decimal.Decimal('1')) == decimal.Decimal('0.025')
 
 
 async def test_calculate_maintenance_margin(future_trader_simulator_with_default_linear):
     config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
     position_inst = personal_data.LinearPosition(trader_inst, default_contract)
-    position_inst.update_from_raw(
-        {
-            enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL
-        }
-    )
+    position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
 
     await position_inst.update(update_size=constants.ZERO, mark_price=constants.ZERO)
     assert position_inst.calculate_maintenance_margin() == constants.ZERO
-    await position_inst.update(update_size=constants.ONE_HUNDRED, mark_price=constants.ONE_HUNDRED)
-    assert position_inst.calculate_maintenance_margin() == constants.ONE_HUNDRED
+    await position_inst.update(update_size=TWELVE_DOT_FIVE, mark_price=FORTY)
+    assert position_inst.calculate_maintenance_margin() == decimal.Decimal('5')
+    # TODO why changing this ? change position_inst.symbol_contract.maintenance_margin_rate instead ?
     exchange_manager_inst.exchange_symbols_data.get_exchange_symbol_data(
         DEFAULT_FUTURE_SYMBOL).funding_manager.funding_rate = decimal.Decimal(DEFAULT_FUTURE_FUNDING_RATE)
-    await position_inst.update(update_size=constants.ONE_HUNDRED, mark_price=constants.ONE_HUNDRED)
-    assert position_inst.calculate_maintenance_margin() == decimal.Decimal('200')
+    await position_inst.update(update_size=TWELVE_DOT_FIVE, mark_price=FORTY)
+    assert position_inst.calculate_maintenance_margin() == decimal.Decimal('10')
 
 
 async def test_update_isolated_liquidation_price_with_long(future_trader_simulator_with_default_linear):
     config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
-    exchange_manager_inst.exchange_symbols_data.get_exchange_symbol_data(
-        DEFAULT_FUTURE_SYMBOL).funding_manager.funding_rate = decimal.Decimal(DEFAULT_FUTURE_FUNDING_RATE)
-
     position_inst = personal_data.LinearPosition(trader_inst, default_contract)
-    position_inst.symbol = DEFAULT_FUTURE_SYMBOL
-    position_inst.entry_price = constants.ONE_HUNDRED
-    await position_inst.update(update_size=constants.ONE_HUNDRED, mark_price=constants.ONE_HUNDRED)
+    position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
+    # avoid default maintenance_margin_rate to change liquidation price
+    default_contract.maintenance_margin_rate = decimal.Decimal("0.2")
+
+    await position_inst.update(update_size=TWENTY_FIVE, mark_price=FORTY)
     position_inst.update_isolated_liquidation_price()
-    assert position_inst.liquidation_price == constants.ONE
+    assert position_inst.liquidation_price == decimal.Decimal('8')
     default_contract.set_current_leverage(constants.ONE_HUNDRED)
-    await position_inst.update(update_size=-constants.ONE_HUNDRED,
-                               mark_price=decimal.Decimal(1.2) * constants.ONE_HUNDRED)
+    position_inst.update_isolated_liquidation_price()
+    assert position_inst.liquidation_price == decimal.Decimal("47.60")
+    # sell whole position
+    await position_inst.update(update_size=-TWENTY_FIVE, mark_price=FORTY * decimal.Decimal(1.2))
     position_inst.update_isolated_liquidation_price()
     assert position_inst.liquidation_price == constants.ZERO
 
@@ -192,56 +347,50 @@ async def test_update_isolated_liquidation_price_with_long(future_trader_simulat
 async def test_update_isolated_liquidation_price_with_short(
         future_trader_simulator_with_default_linear):
     config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
-    exchange_manager_inst.exchange_symbols_data.get_exchange_symbol_data(
-        DEFAULT_FUTURE_SYMBOL).funding_manager.funding_rate = decimal.Decimal(DEFAULT_FUTURE_FUNDING_RATE)
-
     position_inst = personal_data.LinearPosition(trader_inst, default_contract)
-    position_inst.symbol = DEFAULT_FUTURE_SYMBOL
-    position_inst.entry_price = constants.ONE_HUNDRED
-    await position_inst.update(update_size=-constants.ONE_HUNDRED, mark_price=constants.ONE_HUNDRED)
+    position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
+    # avoid default maintenance_margin_rate to change liquidation price
+    default_contract.maintenance_margin_rate = decimal.Decimal("0.2")
+
+    await position_inst.update(update_size=-TWELVE_DOT_FIVE, mark_price=FORTY)
     position_inst.update_isolated_liquidation_price()
-    assert position_inst.liquidation_price == decimal.Decimal("199.0")
+    assert position_inst.liquidation_price == decimal.Decimal("72.0")
     default_contract.set_current_leverage(constants.ONE_HUNDRED)
-    await position_inst.update(update_size=-constants.ONE_HUNDRED,
-                               mark_price=constants.ONE_HUNDRED / decimal.Decimal(10))
     position_inst.update_isolated_liquidation_price()
-    assert position_inst.liquidation_price == decimal.Decimal("100")
+    assert position_inst.liquidation_price == decimal.Decimal("32.40")
+    await position_inst.update(update_size=-TWELVE_DOT_FIVE, mark_price=FORTY / decimal.Decimal(10))
+    position_inst.update_isolated_liquidation_price()
+    assert position_inst.liquidation_price == decimal.Decimal("32.40")
 
 
 async def test_get_bankruptcy_price_with_long(future_trader_simulator_with_default_linear):
     config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
-
     position_inst = personal_data.LinearPosition(trader_inst, default_contract)
     position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
-    position_inst.entry_price = constants.ONE_HUNDRED
-    await position_inst.update(update_size=constants.ONE_HUNDRED, mark_price=constants.ONE_HUNDRED)
+
+    await position_inst.update(update_size=TWELVE_DOT_FIVE, mark_price=FORTY)
     assert position_inst.get_bankruptcy_price() == constants.ZERO
-    assert position_inst.get_bankruptcy_price(with_mark_price=True) == constants.ONE_HUNDRED
+    assert position_inst.get_bankruptcy_price(with_mark_price=True) == FORTY
     default_contract.set_current_leverage(constants.ONE_HUNDRED)
-    assert position_inst.get_bankruptcy_price() == decimal.Decimal("99.00")
-    assert position_inst.get_bankruptcy_price(with_mark_price=True) == decimal.Decimal("100")
-    await position_inst.update(update_size=constants.ONE_HUNDRED,
-                               mark_price=decimal.Decimal(2) * constants.ONE_HUNDRED)
-    assert position_inst.get_bankruptcy_price() == decimal.Decimal("99.00")
-    assert position_inst.get_bankruptcy_price(with_mark_price=True) == decimal.Decimal("200")
+    assert position_inst.get_bankruptcy_price() == decimal.Decimal("39.60")
+    assert position_inst.get_bankruptcy_price(with_mark_price=True) == decimal.Decimal("40")
+    await position_inst.update(update_size=TWELVE_DOT_FIVE, mark_price=FORTY * decimal.Decimal(2))
+    assert position_inst.get_bankruptcy_price() == decimal.Decimal("39.60")
+    assert position_inst.get_bankruptcy_price(with_mark_price=True) == decimal.Decimal("80")
 
 
 async def test_get_bankruptcy_price_with_short(future_trader_simulator_with_default_linear):
     config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
-
     position_inst = personal_data.LinearPosition(trader_inst, default_contract)
     position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
-    position_inst.entry_price = constants.ONE_HUNDRED
-    await position_inst.update(update_size=-constants.ONE_HUNDRED, mark_price=constants.ONE_HUNDRED)
-    assert position_inst.get_bankruptcy_price() == decimal.Decimal("200")
-    assert position_inst.get_bankruptcy_price(with_mark_price=True) == decimal.Decimal("100")
+
+    await position_inst.update(update_size=-TWELVE_DOT_FIVE, mark_price=FORTY)
+    assert position_inst.get_bankruptcy_price() == decimal.Decimal("80")
+    assert position_inst.get_bankruptcy_price(with_mark_price=True) == decimal.Decimal("40")
     default_contract.set_current_leverage(constants.ONE_HUNDRED)
-    assert position_inst.get_bankruptcy_price() == decimal.Decimal('101.00')
-    assert position_inst.get_bankruptcy_price(with_mark_price=True) == decimal.Decimal('100')
-    exchange_manager_inst.exchange_personal_data.portfolio_manager.portfolio.get_currency_portfolio(
-        "USDT").wallet_balance = decimal.Decimal(10000)  # TO prevent portfolio negative error
-    await position_inst.update(update_size=constants.ONE_HUNDRED,
-                               mark_price=decimal.Decimal(2) * constants.ONE_HUNDRED)
+    assert position_inst.get_bankruptcy_price() == decimal.Decimal('40.4')
+    assert position_inst.get_bankruptcy_price(with_mark_price=True) == decimal.Decimal('40')
+    await position_inst.update(update_size=TWELVE_DOT_FIVE, mark_price=FORTY * decimal.Decimal(2))
     assert position_inst.get_bankruptcy_price() == constants.ZERO
     assert position_inst.get_bankruptcy_price(with_mark_price=True) == constants.ZERO
 
@@ -253,8 +402,8 @@ async def test_get_order_cost(future_trader_simulator_with_default_linear):
 
     await position_inst.update(update_size=constants.ZERO, mark_price=constants.ZERO)
     assert position_inst.get_order_cost() == constants.ZERO
-    await position_inst.update(update_size=constants.ONE_HUNDRED, mark_price=constants.ONE_HUNDRED)
-    assert position_inst.get_order_cost() == decimal.Decimal("10020.000")
+    await position_inst.update(update_size=TWENTY_FIVE, mark_price=FORTY)
+    assert position_inst.get_order_cost() == decimal.Decimal("1000.008")
 
 
 async def test_get_fee_to_open(future_trader_simulator_with_default_linear):
@@ -264,30 +413,27 @@ async def test_get_fee_to_open(future_trader_simulator_with_default_linear):
 
     await position_inst.update(update_size=constants.ZERO, mark_price=constants.ZERO)
     assert position_inst.get_fee_to_open() == constants.ZERO
-    await position_inst.update(update_size=constants.ONE_HUNDRED, mark_price=constants.ONE_HUNDRED)
-    assert position_inst.get_fee_to_open() == decimal.Decimal("10.000")
+    await position_inst.update(update_size=TWENTY_FIVE, mark_price=FORTY)
+    assert position_inst.get_fee_to_open() == decimal.Decimal("0.004")
 
 
 async def test_update_fee_to_close(future_trader_simulator_with_default_linear):
     config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
     position_inst = personal_data.LinearPosition(trader_inst, default_contract)
-    position_inst.update_from_raw(
-        {
-            enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL
-        }
-    )
+    position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
 
     await position_inst.update(update_size=constants.ZERO, mark_price=constants.ZERO)
     position_inst.update_fee_to_close()
     assert position_inst.fee_to_close == constants.ZERO
-    await position_inst.update(update_size=constants.ONE_HUNDRED, mark_price=constants.ONE_HUNDRED)
+    await position_inst.update(update_size=TWENTY_FIVE, mark_price=FORTY)
     position_inst.update_fee_to_close()
-    assert position_inst.fee_to_close == decimal.Decimal("10")
+    assert position_inst.fee_to_close == decimal.Decimal("0.004")
 
 
 async def test_update_average_entry_price_increased_long(future_trader_simulator_with_default_linear):
     config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
     position_inst = personal_data.LinearPosition(trader_inst, default_contract)
+    position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
 
     await position_inst.update(update_size=decimal.Decimal(10), mark_price=decimal.Decimal(10))
     position_inst.entry_price = decimal.Decimal(10)
@@ -302,6 +448,7 @@ async def test_update_average_entry_price_increased_long(future_trader_simulator
 async def test_update_average_entry_price_increased_short(future_trader_simulator_with_default_linear):
     config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
     position_inst = personal_data.LinearPosition(trader_inst, default_contract)
+    position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
 
     await position_inst.update(update_size=-decimal.Decimal(10), mark_price=decimal.Decimal(10))
     position_inst.entry_price = decimal.Decimal(10)
@@ -316,6 +463,7 @@ async def test_update_average_entry_price_increased_short(future_trader_simulato
 async def test_update_average_entry_price_decreased_long(future_trader_simulator_with_default_linear):
     config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
     position_inst = personal_data.LinearPosition(trader_inst, default_contract)
+    position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
 
     await position_inst.update(update_size=decimal.Decimal(100), mark_price=decimal.Decimal(10))
     position_inst.entry_price = decimal.Decimal(10)
@@ -330,6 +478,7 @@ async def test_update_average_entry_price_decreased_long(future_trader_simulator
 async def test_update_average_entry_price_decreased_short(future_trader_simulator_with_default_linear):
     config, exchange_manager_inst, trader_inst, default_contract = future_trader_simulator_with_default_linear
     position_inst = personal_data.LinearPosition(trader_inst, default_contract)
+    position_inst.update_from_raw({enums.ExchangeConstantsPositionColumns.SYMBOL.value: DEFAULT_FUTURE_SYMBOL})
 
     await position_inst.update(update_size=-decimal.Decimal(100), mark_price=decimal.Decimal(10))
     position_inst.entry_price = decimal.Decimal(10)


### PR DESCRIPTION
When an order is filled, we need to update each and every element in future portfolio at once otherwise:
- we allow for incomplete portfolio update (like order_margin sucessful updated but failed position_margin update, etc)
- when using large orders, we end up with neg portfolio issues when trying to reduce the order_margin before reducing the position marging (when computing asset.available as we do `self.wallet_balance - self.position_margin - self.order_margin`)