### PR TITLE
Up groups

### DIFF
--- a/octobot_trading/personal_data/orders/decimal_order_adapter.pxd
+++ b/octobot_trading/personal_data/orders/decimal_order_adapter.pxd
@@ -15,9 +15,9 @@
 #  You should have received a copy of the GNU Lesser General Public
 #  License along with this library.
 
-cpdef object decimal_adapt_price(dict symbol_market, object price)
-cpdef object decimal_adapt_quantity(dict symbol_market, object quantity)
+cpdef object decimal_adapt_price(dict symbol_market, object price, bint truncate=*)
+cpdef object decimal_adapt_quantity(dict symbol_market, object quantity, bint truncate=*)
 cpdef list decimal_adapt_order_quantity_because_quantity(object limiting_value, object max_value, object quantity_to_adapt, object price, dict symbol_market)
 cpdef list decimal_adapt_order_quantity_because_price(object limiting_value, object max_value, object price, dict symbol_market)
 cpdef list decimal_split_orders(object total_order_price, object max_cost, object valid_quantity, object max_quantity, object price, object quantity, dict symbol_market)
-cpdef decimal_check_and_adapt_order_details_if_necessary(object quantity, object price, dict symbol_market, object fixed_symbol_data=*)
+cpdef decimal_check_and_adapt_order_details_if_necessary(object quantity, object price, dict symbol_market, object fixed_symbol_data=*, bint truncate=*)

--- a/octobot_trading/personal_data/orders/groups/balanced_take_profit_and_stop_order_group.pxd
+++ b/octobot_trading/personal_data/orders/groups/balanced_take_profit_and_stop_order_group.pxd
@@ -20,3 +20,4 @@ cdef class BalancedTakeProfitAndStopOrderGroup(order_group.OrderGroup):
     cdef public list balancing_orders
 
     cpdef bint can_create_order(self, object order_type, object quantity)
+    cpdef object get_max_order_quantity(self, object order_type)

--- a/octobot_trading/personal_data/orders/groups/balanced_take_profit_and_stop_order_group.py
+++ b/octobot_trading/personal_data/orders/groups/balanced_take_profit_and_stop_order_group.py
@@ -72,6 +72,19 @@ class BalancedTakeProfitAndStopOrderGroup(order_group.OrderGroup):
             return balance[self.STOP].get_balance() + quantity <= balance[self.TAKE_PROFIT].get_balance()
         return balance[self.TAKE_PROFIT].get_balance() + quantity <= balance[self.STOP].get_balance()
 
+    def get_max_order_quantity(self, order_type):
+        """
+        Returns The maximum order quantity to reach the order side's balance
+        :param order_type: order type to create
+        :return: the balancing quantity
+        """
+        balance = self._get_balance(None, None)
+        if order_util.is_stop_order(order_type):
+            max_quantity = balance[self.TAKE_PROFIT].get_balance() - balance[self.STOP].get_balance()
+        else:
+            max_quantity = balance[self.STOP].get_balance() - balance[self.TAKE_PROFIT].get_balance()
+        return max_quantity if max_quantity > constants.ZERO else constants.ZERO
+
     async def enable(self, enabled):
         # disable when creating order sequentially (and therefore pause balancing)
         # setting enabled to True will trigger an order balance

--- a/tests/personal_data/orders/test_decimal_order_adapter.py
+++ b/tests/personal_data/orders/test_decimal_order_adapter.py
@@ -57,6 +57,22 @@ async def test_decimal_adapt_price():
     assert personal_data.decimal_adapt_price(symbol_market,
                                              decimal.Decimal(str(1251.0000014576121234854513))) == decimal.Decimal(
         str(1251.00000145))
+    assert personal_data.decimal_adapt_price(symbol_market,
+                                             decimal.Decimal(str(1251.0000014576121234854513)),
+                                             True) == decimal.Decimal(
+        str(1251.00000145))
+    assert personal_data.decimal_adapt_price(symbol_market,
+                                             decimal.Decimal(str(1251.0000014576121234854513)),
+                                             False) == decimal.Decimal(
+        str(1251.00000146))
+    assert personal_data.decimal_adapt_price(symbol_market,
+                                             decimal.Decimal(str(1251.000001451)),
+                                             True) == decimal.Decimal(
+        str(1251.00000145))
+    assert personal_data.decimal_adapt_price(symbol_market,
+                                             decimal.Decimal(str(1251.000001451)),
+                                             False) == decimal.Decimal(
+        str(1251.00000146))
 
 
 async def test_decimal_check_and_adapt_order_details_if_necessary():
@@ -386,6 +402,14 @@ async def test_adapt_quantity():
     assert personal_data.decimal_adapt_quantity(symbol_market,
                                                 decimal.Decimal(str(1251.0000014576121234854513))) == decimal.Decimal(
         str(1251.0000))
+    assert personal_data.decimal_adapt_quantity(symbol_market,
+                                                decimal.Decimal(str(1251.0000014576121234854513)),
+                                                True) == decimal.Decimal(
+        str(1251.0000))
+    assert personal_data.decimal_adapt_quantity(symbol_market,
+                                                decimal.Decimal(str(1251.0000014576121234854513)),
+                                                False) == decimal.Decimal(
+        str(1251.0001))
 
     # will use default (0)
     symbol_market = {Ecmsc.PRECISION.value: {}}
@@ -404,6 +428,10 @@ async def test_adapt_quantity():
 
 
 async def test_decimal_trunc_with_n_decimal_digits():
+    assert personal_data.decimal_trunc_with_n_decimal_digits(decimal.Decimal(1.00000000001), 10) == decimal.Decimal(1)
+    assert personal_data.decimal_trunc_with_n_decimal_digits(decimal.Decimal("1.01"), 1, True) == decimal.Decimal(1)
+    assert personal_data.decimal_trunc_with_n_decimal_digits(decimal.Decimal("1.01"), 1, False) \
+        == decimal.Decimal("1.1")
     assert float(personal_data.decimal_trunc_with_n_decimal_digits(decimal.Decimal(1.00000000001), 10)) == 1
     assert float(personal_data.decimal_trunc_with_n_decimal_digits(decimal.Decimal(1.00000000001), 11)) == 1.00000000001
     assert float(personal_data.decimal_trunc_with_n_decimal_digits(decimal.Decimal(578.000145000156), 3)) == 578


### PR DESCRIPTION
required tools to fix rounding issues (due to exchange max precision) on multiple sell profits (ex: position of 20.1 translated into 2 sell orders of 10 instead of one of 10.1 and one of 10)