### PR TITLE
Fix args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.11] - 2022-08-31
+### Fixed
+- [Exchanges] kwargs usage and attributes visibility
+
 ## [2.2.10] - 2022-08-23
 ### Fixed
 - [Supports] Fix use support call

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OctoBot-Trading [2.2.10](https://github.com/Drakkar-Software/OctoBot-Trading/blob/master/CHANGELOG.md)
+# OctoBot-Trading [2.2.11](https://github.com/Drakkar-Software/OctoBot-Trading/blob/master/CHANGELOG.md)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/903b6b22bceb4661b608a86fea655f69)](https://app.codacy.com/gh/Drakkar-Software/OctoBot-Trading?utm_source=github.com&utm_medium=referral&utm_content=Drakkar-Software/OctoBot-Trading&utm_campaign=Badge_Grade_Dashboard)
 [![PyPI](https://img.shields.io/pypi/v/OctoBot-Trading.svg)](https://pypi.python.org/pypi/OctoBot-Trading/)
 [![Coverage Status](https://coveralls.io/repos/github/Drakkar-Software/OctoBot-Trading/badge.svg?branch=master)](https://coveralls.io/github/Drakkar-Software/OctoBot-Trading?branch=master)

--- a/octobot_trading/__init__.py
+++ b/octobot_trading/__init__.py
@@ -15,4 +15,4 @@
 #  License along with this library.
 
 PROJECT_NAME = "OctoBot-Trading"
-VERSION = "2.2.10"  # major.minor.revision
+VERSION = "2.2.11"  # major.minor.revision

--- a/octobot_trading/exchange_data/funding/channel/funding.py
+++ b/octobot_trading/exchange_data/funding/channel/funding.py
@@ -28,17 +28,17 @@ class FundingProducer(exchanges_channel.ExchangeChannelProducer):
             if self.channel.get_filtered_consumers(
                     symbol=constants.CHANNEL_WILDCARD) or self.channel.get_filtered_consumers(symbol=symbol):
                 await self.channel.exchange_manager.get_symbol_data(symbol) \
-                    .handle_funding_update(funding_rate=funding_rate,
-                                           predicted_funding_rate=predicted_funding_rate,
-                                           next_funding_time=next_funding_time,
-                                           timestamp=timestamp)
-                await self.send(cryptocurrency=self.channel.exchange_manager.exchange.
+                    .handle_funding_update(funding_rate,
+                                           predicted_funding_rate,
+                                           next_funding_time,
+                                           timestamp)
+                await self.send(self.channel.exchange_manager.exchange.
                                 get_pair_cryptocurrency(symbol),
-                                symbol=symbol,
-                                funding_rate=funding_rate,
-                                predicted_funding_rate=predicted_funding_rate,
-                                next_funding_time=next_funding_time,
-                                timestamp=timestamp)
+                                symbol,
+                                funding_rate,
+                                predicted_funding_rate,
+                                next_funding_time,
+                                timestamp)
         except asyncio.CancelledError:
             self.logger.info("Update tasks cancelled.")
         except Exception as e:

--- a/octobot_trading/exchange_data/funding/channel/funding_updater.py
+++ b/octobot_trading/exchange_data/funding/channel/funding_updater.py
@@ -123,11 +123,11 @@ class FundingUpdater(funding_channel.FundingProducer):
         if next_funding_time is None:
             next_funding_time = last_funding_time + self.FUNDING_REFRESH_TIME_MAX
         await self.push(
-            symbol=symbol,
-            funding_rate=funding_rate,
-            predicted_funding_rate=predicted_funding_rate,
-            next_funding_time=next_funding_time,
-            timestamp=last_funding_time,
+            symbol,
+            funding_rate,
+            predicted_funding_rate,
+            next_funding_time,
+            last_funding_time,
         )
 
     def _should_run(self):

--- a/octobot_trading/exchange_data/order_book/channel/order_book_updater.py
+++ b/octobot_trading/exchange_data/order_book/channel/order_book_updater.py
@@ -77,9 +77,9 @@ class OrderBookUpdater(order_book_channel.OrderBookProducer):
             if asks and bids:
                 await exchanges_channel.get_chan(constants.ORDER_BOOK_TICKER_CHANNEL,
                                                  self.channel.exchange_manager.id).get_internal_producer(). \
-                    push(symbol=pair,
-                         ask_quantity=asks[0][1], ask_price=asks[0][0],
-                         bid_quantity=bids[0][1], bid_price=bids[0][0])
+                    push(pair,
+                         asks[0][1], asks[0][0],
+                         bids[0][1], bids[0][0])
         except Exception as e:
             self.logger.error(f"Failed to parse order book ticker : {e}")
 

--- a/octobot_trading/exchange_data/prices/channel/prices_updater.py
+++ b/octobot_trading/exchange_data/prices/channel/prices_updater.py
@@ -138,10 +138,11 @@ class MarkPriceUpdater(prices_channel.MarkPriceProducer):
         if funding_rate:
             await exchanges_channel.get_chan(constants.FUNDING_CHANNEL,
                                              self.channel.exchange_manager.id).get_internal_producer(). \
-                push(symbol=symbol,
-                     funding_rate=funding_rate[enums.ExchangeConstantsFundingColumns.FUNDING_RATE.value],
-                     next_funding_time=funding_rate[enums.ExchangeConstantsFundingColumns.NEXT_FUNDING_TIME.value],
-                     timestamp=funding_rate[enums.ExchangeConstantsFundingColumns.LAST_FUNDING_TIME.value])
+                push(symbol,
+                     funding_rate[enums.ExchangeConstantsFundingColumns.FUNDING_RATE.value],
+                     funding_rate.get(enums.ExchangeConstantsFundingColumns.PREDICTED_FUNDING_RATE.value, 0),
+                     funding_rate[enums.ExchangeConstantsFundingColumns.NEXT_FUNDING_TIME.value],
+                     funding_rate[enums.ExchangeConstantsFundingColumns.LAST_FUNDING_TIME.value])
 
     def _should_fetch_on_exchange(self) -> bool:
         return not (

--- a/octobot_trading/exchange_data/ticker/channel/ticker_updater.py
+++ b/octobot_trading/exchange_data/ticker/channel/ticker_updater.py
@@ -111,7 +111,7 @@ class TickerUpdater(ticker_channel.TickerProducer):
         try:
             await exchanges_channel.get_chan(constants.MINI_TICKER_CHANNEL,
                                              self.channel.exchange_manager.id).get_internal_producer(). \
-                push(symbol=pair, mini_ticker={
+                push(pair, {
                 enums.ExchangeConstantsMiniTickerColumns.HIGH_PRICE.value:
                     ticker[enums.ExchangeConstantsTickersColumns.HIGH.value],
                 enums.ExchangeConstantsMiniTickerColumns.LOW_PRICE.value:
@@ -150,8 +150,8 @@ class TickerUpdater(ticker_channel.TickerProducer):
             ticker = self.channel.exchange_manager.exchange.parse_mark_price(ticker, from_ticker=True)
             await exchanges_channel.get_chan(constants.MARK_PRICE_CHANNEL,
                                              self.channel.exchange_manager.id).get_internal_producer(). \
-                push(symbol=symbol,
-                     mark_price=decimal.Decimal(str(ticker[enums.ExchangeConstantsMarkPriceColumns.MARK_PRICE.value])))
+                push(symbol,
+                     decimal.Decimal(str(ticker[enums.ExchangeConstantsMarkPriceColumns.MARK_PRICE.value])))
         except Exception as e:
             self.logger.exception(e, True, f"Fail to update mark price from ticker : {e}")
 
@@ -160,13 +160,11 @@ class TickerUpdater(ticker_channel.TickerProducer):
             ticker = self.channel.exchange_manager.exchange.parse_funding(ticker, from_ticker=True)
             await exchanges_channel.get_chan(constants.FUNDING_CHANNEL,
                                              self.channel.exchange_manager.id).get_internal_producer(). \
-                push(symbol=symbol,
-                     funding_rate=decimal.Decimal(str(
-                         ticker[enums.ExchangeConstantsFundingColumns.FUNDING_RATE.value])),
-                     predicted_funding_rate=decimal.Decimal(str(
-                         ticker[enums.ExchangeConstantsFundingColumns.PREDICTED_FUNDING_RATE.value])),
-                     next_funding_time=ticker[enums.ExchangeConstantsFundingColumns.NEXT_FUNDING_TIME.value],
-                     timestamp=ticker[enums.ExchangeConstantsFundingColumns.LAST_FUNDING_TIME.value])
+                push(symbol,
+                     decimal.Decimal(str(ticker[enums.ExchangeConstantsFundingColumns.FUNDING_RATE.value])),
+                     decimal.Decimal(str(ticker[enums.ExchangeConstantsFundingColumns.PREDICTED_FUNDING_RATE.value])),
+                     ticker[enums.ExchangeConstantsFundingColumns.NEXT_FUNDING_TIME.value],
+                     ticker[enums.ExchangeConstantsFundingColumns.LAST_FUNDING_TIME.value])
         except Exception as e:
             self.logger.exception(e, True, f"Fail to update funding rate from ticker : {e}")
 

--- a/octobot_trading/exchanges/abstract_websocket_exchange.py
+++ b/octobot_trading/exchanges/abstract_websocket_exchange.py
@@ -71,10 +71,10 @@ class AbstractWebsocketExchange:
         """
         return self.exchange_manager.get_exchange_credentials(self.logger, self.exchange_manager.exchange_name)
 
-    async def push_to_channel(self, channel_name, **kwargs):
+    async def push_to_channel(self, channel_name, *args, **kwargs):
         try:
             asyncio.run_coroutine_threadsafe(
-                exchange_channel.get_chan(channel_name, self.exchange_id).get_internal_producer().push(**kwargs),
+                exchange_channel.get_chan(channel_name, self.exchange_id).get_internal_producer().push(*args, **kwargs),
                 self.bot_mainloop)
         except Exception as e:
             self.logger.error(f"Push to {channel_name} failed : {e}")

--- a/octobot_trading/exchanges/types/future_exchange.pxd
+++ b/octobot_trading/exchanges/types/future_exchange.pxd
@@ -18,7 +18,7 @@ cimport octobot_trading.exchanges.abstract_exchange as abstract_exchange
 cimport octobot_trading.exchange_data.contracts as contracts
 
 cdef class FutureExchange(abstract_exchange.AbstractExchange):
-    cdef dict pair_contracts
+    cdef public dict pair_contracts
 
     cpdef void create_pair_contract(self, str pair,
                                     object current_leverage, object margin_type,

--- a/octobot_trading/modes/abstract_trading_mode.py
+++ b/octobot_trading/modes/abstract_trading_mode.py
@@ -298,7 +298,7 @@ class AbstractTradingMode(abstract_tentacle.AbstractTentacle):
                     (self.get_name(), )
                 ) as signal_builder:
                     yield signal_builder
-            except authentication.AuthenticationRequired as e:
+            except (authentication.AuthenticationRequired, authentication.UnavailableError) as e:
                 self.logger.exception(e, True, f"Failed to send trading signals: {e}")
         else:
             yield None

--- a/octobot_trading/personal_data/orders/channel/orders_updater.py
+++ b/octobot_trading/personal_data/orders/channel/orders_updater.py
@@ -99,7 +99,7 @@ class OrdersUpdater(orders_channel.OrdersProducer):
         for symbol in self.channel.exchange_manager.exchange_config.traded_symbol_pairs:
             open_orders: list = await self.channel.exchange_manager.exchange.get_open_orders(symbol=symbol, limit=limit)
             if open_orders:
-                await self.push(orders=list(map(self.channel.exchange_manager.exchange.clean_order, open_orders)),
+                await self.push(list(map(self.channel.exchange_manager.exchange.clean_order, open_orders)),
                                 is_from_bot=is_from_bot)
             else:
                 await self.handle_post_open_order_update(symbol, open_orders, False)
@@ -114,7 +114,7 @@ class OrdersUpdater(orders_channel.OrdersProducer):
                 symbol=symbol, limit=limit)
 
             if close_orders:
-                await self.push(orders=list(map(self.channel.exchange_manager.exchange.clean_order, close_orders)),
+                await self.push(list(map(self.channel.exchange_manager.exchange.clean_order, close_orders)),
                                 are_closed=True)
 
     async def update_order_from_exchange(self, order,

--- a/octobot_trading/personal_data/positions/channel/positions_updater.py
+++ b/octobot_trading/personal_data/positions/channel/positions_updater.py
@@ -155,7 +155,7 @@ class PositionsUpdater(positions_channel.PositionsProducer):
             await self._push_positions(positions)
 
     async def _push_positions(self, positions):
-        await self.push(positions=positions)
+        await self.push(positions)
 
         if self._should_push_mark_price():
             for position in positions:
@@ -180,8 +180,8 @@ class PositionsUpdater(positions_channel.PositionsProducer):
         try:
             await exchanges_channel.get_chan(constants.MARK_PRICE_CHANNEL,
                                              self.channel.exchange_manager.id).get_internal_producer(). \
-                push(symbol=position_dict[enums.ExchangeConstantsPositionColumns.SYMBOL.value],
-                     mark_price=position_dict[enums.ExchangeConstantsPositionColumns.MARK_PRICE.value])
+                push(position_dict[enums.ExchangeConstantsPositionColumns.SYMBOL.value],
+                     position_dict[enums.ExchangeConstantsPositionColumns.MARK_PRICE.value])
         except Exception as e:
             self.logger.exception(e, True, f"Fail to update mark price from position : {e}")
 

--- a/octobot_trading/personal_data/trades/channel/trades_updater.py
+++ b/octobot_trading/personal_data/trades/channel/trades_updater.py
@@ -61,7 +61,7 @@ class TradesUpdater(trades_channel.TradesProducer):
                 limit=self.MAX_OLD_TRADES_TO_FETCH)
 
             if trades:
-                await self.push(trades=list(map(self.channel.exchange_manager.exchange.clean_trade, trades)))
+                await self.push(list(map(self.channel.exchange_manager.exchange.clean_trade, trades)))
 
     async def start(self):
         if util.is_trade_history_loading_enabled(self.channel.exchange_manager.config):


### PR DESCRIPTION
fixes 
![image](https://user-images.githubusercontent.com/9078616/187802780-b1a763f1-08da-420f-9a04-4db51136933a.png)

=> I don't really understand why sometimes it works and sometimes it doesnt, it probably has to do with something about cython. Anyway I think it's better not to use kw args when function args are positional and not keyword ones.