### PR TITLE
[Ticker] properly handle exchanges with MARK_PRICE_IN_TICKER

### DIFF
--- a/octobot_trading/exchange_data/ticker/channel/ticker.py
+++ b/octobot_trading/exchange_data/ticker/channel/ticker.py
@@ -103,7 +103,7 @@ class TickerProducer(exchanges_channel.ExchangeChannelProducer):
                                              self.channel.exchange_manager.id).get_internal_producer().push(
                 symbol,
                 decimal.Decimal(str(ticker[enums.ExchangeConstantsMarkPriceColumns.MARK_PRICE.value])),
-                mark_price_source=enums.MarkPriceSources.TICKER_CLOSE_PRICE.value
+                mark_price_source=enums.MarkPriceSources.EXCHANGE_MARK_PRICE.value
             )
         except Exception as e:
             self.logger.exception(e, True, f"Fail to update mark price from ticker : {e}")


### PR DESCRIPTION
Binance usdm uses MARK_PRICE_IN_TICKER which is getting treated as a secondary source and mark price will get overwritten by mark price from recent trades.

With this change mark price from ticker will work properly

This was not used before by, so thats why nobody noticed