### PR TITLE
Fix close & init mark price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.20] - 2023-02-13
+### Fixed
+- [CCXT] Don't clear throttler queue on close
+
 ## [2.3.19] - 2023-02-12
 ### Updated
 - [Memory] Improve memory management

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OctoBot-Trading [2.3.19](https://github.com/Drakkar-Software/OctoBot-Trading/blob/master/CHANGELOG.md)
+# OctoBot-Trading [2.3.20](https://github.com/Drakkar-Software/OctoBot-Trading/blob/master/CHANGELOG.md)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/903b6b22bceb4661b608a86fea655f69)](https://app.codacy.com/gh/Drakkar-Software/OctoBot-Trading?utm_source=github.com&utm_medium=referral&utm_content=Drakkar-Software/OctoBot-Trading&utm_campaign=Badge_Grade_Dashboard)
 [![PyPI](https://img.shields.io/pypi/v/OctoBot-Trading.svg)](https://pypi.python.org/pypi/OctoBot-Trading/)
 [![Coverage Status](https://coveralls.io/repos/github/Drakkar-Software/OctoBot-Trading/badge.svg?branch=master)](https://coveralls.io/github/Drakkar-Software/OctoBot-Trading?branch=master)

--- a/octobot_trading/__init__.py
+++ b/octobot_trading/__init__.py
@@ -15,4 +15,4 @@
 #  License along with this library.
 
 PROJECT_NAME = "OctoBot-Trading"
-VERSION = "2.3.19"  # major.minor.revision
+VERSION = "2.3.20"  # major.minor.revision

--- a/octobot_trading/enums.py
+++ b/octobot_trading/enums.py
@@ -391,6 +391,7 @@ class MarkPriceSources(enum.Enum):
     EXCHANGE_MARK_PRICE = "exchange_mark_price"
     RECENT_TRADE_AVERAGE = "recent_trade_average"
     TICKER_CLOSE_PRICE = "ticker_close_price"
+    CANDLE_CLOSE_PRICE = "candle_close_price"
 
 
 class WebsocketFeeds(enum.Enum):

--- a/octobot_trading/exchange_data/ohlcv/channel/ohlcv_updater.pxd
+++ b/octobot_trading/exchange_data/ohlcv/channel/ohlcv_updater.pxd
@@ -28,3 +28,4 @@ cdef class OHLCVUpdater(ohlcv_channel.OHLCVProducer):
     cdef int _get_historical_candles_count(self)
     cdef double _ensure_correct_sleep_time(self, double sleep_time_candidate, double time_frame_sleep)
     cdef void _set_initialized(self, str pair, object time_frame, bint initialized)
+    cdef void _set_mark_price_from_candle(self, str pair, list candle)

--- a/octobot_trading/exchange_data/prices/channel/prices_updater.py
+++ b/octobot_trading/exchange_data/prices/channel/prices_updater.py
@@ -84,8 +84,11 @@ class MarkPriceUpdater(prices_channel.MarkPriceProducer):
         """
         try:
             mark_price = prices_manager.calculate_mark_price_from_recent_trade_prices(
-                [decimal.Decimal(str(last_price[enums.ExchangeConstantsOrderColumns.PRICE.value]))
-                 for last_price in recent_trades])
+                [
+                    decimal.Decimal(str(last_price[enums.ExchangeConstantsOrderColumns.PRICE.value]))
+                    for last_price in recent_trades
+                ]
+            )
 
             await self.push(symbol, mark_price, mark_price_source=enums.MarkPriceSources.RECENT_TRADE_AVERAGE.value)
         except Exception as e:

--- a/octobot_trading/exchange_data/prices/prices_manager.py
+++ b/octobot_trading/exchange_data/prices/prices_manager.py
@@ -78,8 +78,9 @@ class PricesManager(util.Initializable):
                 self.mark_price_from_sources[mark_price_source] = (mark_price, 0)
 
         # set mark price value if other sources have expired
-        elif mark_price_source == enums.MarkPriceSources.TICKER_CLOSE_PRICE.value and not \
-                self._are_other_sources_valid(enums.MarkPriceSources.TICKER_CLOSE_PRICE.value):
+        elif mark_price_source in (enums.MarkPriceSources.TICKER_CLOSE_PRICE.value,
+                                   enums.MarkPriceSources.CANDLE_CLOSE_PRICE.value) and not \
+                self._are_other_sources_valid(mark_price_source):
             self._set_mark_price_value(mark_price)
             is_mark_price_updated = True
 
@@ -104,10 +105,9 @@ class PricesManager(util.Initializable):
                     raise asyncio.TimeoutError()
                 await asyncio.wait_for(self.valid_price_received_event.wait(), timeout)
             except asyncio.TimeoutError:
-                self.logger.warning("Timeout when waiting for current market price. This probably means that too many "
-                                    "trading pairs are being used at the same time and the exchange's rate limit is "
-                                    "preventing OctoBot from working properly. If this issue persists, please consider "
-                                    "using websocket connections.")
+                self.logger.warning("Timeout when waiting for current market price. This probably means that the "
+                                    "required mark price market as a very low liquidity. Market price will be "
+                                    "available as soon as a trade will happen on this market.")
                 raise
         return self.mark_price
 

--- a/octobot_trading/exchange_data/recent_trades/recent_trades_manager.py
+++ b/octobot_trading/exchange_data/recent_trades/recent_trades_manager.py
@@ -44,7 +44,8 @@ class RecentTradesManager(util.Initializable):
             new_recent_trades: list = [
                 trade
                 for trade in recent_trades
-                if trade not in self.recent_trades]
+                if trade not in self.recent_trades
+            ]
             self.recent_trades.extend(new_recent_trades)
             return new_recent_trades
 

--- a/octobot_trading/exchanges/connectors/ccxt/ccxt_client_util.py
+++ b/octobot_trading/exchanges/connectors/ccxt/ccxt_client_util.py
@@ -79,8 +79,6 @@ async def close_client(client):
     client.ohlcvs = {}
     client.trades = {}
     client.orderbooks = {}
-    throttler = client.throttle
-    throttler.queue.clear()
 
 
 def get_unauthenticated_exchange(exchange_class, options, headers, additional_config):


### PR DESCRIPTION
- clearing the queue is preventing the exchange from properly close (seen when stopping an in-progress data collector)
- handle mark price from init candles to allow trading low liquidity pairs at bot startup