### PR TITLE
[MarketOrders] forced disable order set price when creating market or…

### DIFF
--- a/octobot_trading/exchanges/connectors/ccxt/ccxt_client_util.py
+++ b/octobot_trading/exchanges/connectors/ccxt/ccxt_client_util.py
@@ -96,6 +96,8 @@ def set_sandbox_mode(exchange_connector, is_sandboxed):
         exchange_connector.logger.warning(f"{exchange_connector.name} does not support sandboxing {additional_info}: {e}")
         # raise exception to stop this exchange and prevent dealing with a real funds exchange
         raise e
+    return None
+
 
 def get_ccxt_client_login_options(exchange_manager):
     """

--- a/octobot_trading/exchanges/connectors/ccxt/ccxt_websocket_connector.py
+++ b/octobot_trading/exchanges/connectors/ccxt/ccxt_websocket_connector.py
@@ -176,7 +176,8 @@ class CCXTWebsocketConnector(abstract_websocket_exchange.AbstractWebsocketExchan
         if self._reconnect_task is not None and not self._reconnect_task.done():
             self._reconnect_task.cancel()
         try:
-            await self.client.close()
+            if self.client is not None:
+                await self.client.close()
             self.stopped_event.set()
         except Exception as e:
             self.logger.exception(e, False)
@@ -295,7 +296,7 @@ class CCXTWebsocketConnector(abstract_websocket_exchange.AbstractWebsocketExchan
                 self.logger.exception(err, True, f"Error when trigger exchange auto-reconnect: {err}")
 
     async def _close_exchange_to_force_reconnect(self):
-        if time.time() - self._last_close_time > self.MIN_CONNECTION_CLOSE_INTERVAL:
+        if time.time() - self._last_close_time > self.MIN_CONNECTION_CLOSE_INTERVAL and not self.should_stop:
             # Close client to force connections re-open. The next watch_xyz will recreate the connection
             self.logger.debug(f"Closing exchange connection.")
             await ccxt_client_util.close_client(self.client)

--- a/octobot_trading/personal_data/orders/order.pxd
+++ b/octobot_trading/personal_data/orders/order.pxd
@@ -121,6 +121,7 @@ cdef class Order(util.Initializable):
     cpdef bint is_short(self)
     cpdef bint is_refreshing(self)
     cpdef bint can_be_edited(self)
+    cpdef bint use_current_price_as_origin_price(self)
     cpdef object get_position_side(self, object future_contract)
     cpdef void on_fill_actions(self)
     cpdef bint has_exchange_fetched_fees(self)

--- a/octobot_trading/personal_data/orders/order.py
+++ b/octobot_trading/personal_data/orders/order.py
@@ -132,6 +132,8 @@ class Order(util.Initializable):
         changed: bool = False
         should_update_total_cost = False
 
+        price = current_price if self.use_current_price_as_origin_price() else price
+
         if order_id and self.order_id != order_id:
             self.order_id = order_id
 
@@ -331,6 +333,10 @@ class Order(util.Initializable):
     def can_be_edited(self):
         # orders that are not yet open or already open can be edited
         return self.state is None or (self.state.is_open() and not self.is_refreshing())
+
+    def use_current_price_as_origin_price(self):
+        # Override to return True when the current order price can't be set by the user (ex: market orders)
+        return False
 
     def get_position_side(self, future_contract):
         """

--- a/octobot_trading/personal_data/orders/types/market/market_order.py
+++ b/octobot_trading/personal_data/orders/types/market/market_order.py
@@ -38,3 +38,8 @@ class MarketOrder(order_class.Order):
     def can_be_edited(self):
         # instantly filled orders can't be edited
         return False
+
+    def use_current_price_as_origin_price(self):
+        # Override to return True when the current order price can't be set by the user (ex: market orders)
+        return True
+

--- a/tests/exchanges/implementations/test_default_websocket_exchange.py
+++ b/tests/exchanges/implementations/test_default_websocket_exchange.py
@@ -21,7 +21,7 @@ import octobot_trading.exchanges as exchanges
 import octobot_trading.enums as enums
 import pytest
 
-from tests.exchanges import exchange_manager, DEFAULT_EXCHANGE_NAME
+from tests.exchanges import exchange_manager as exchange_manager_fixture, DEFAULT_EXCHANGE_NAME
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -119,8 +119,8 @@ class MockedWebSocketExchange(exchanges.DefaultWebSocketExchange):
 
 
 @pytest.fixture
-def default_websocket_exchange(exchange_manager):
-    return MockedWebSocketExchange(exchange_manager.config, exchange_manager)
+def default_websocket_exchange(exchange_manager_fixture):
+    yield MockedWebSocketExchange(exchange_manager_fixture.config, exchange_manager_fixture)
 
 
 async def test_start_receive_feeds_and_stop(default_websocket_exchange):


### PR DESCRIPTION
allows to set input price in order factory with market orders (which now wont be used). Without it, it's breaking the bot by desync portfolio available and total values
requires https://github.com/Drakkar-Software/OctoBot-Trading/pull/845