### PR TITLE
[TradingModeConsumer] improve MissingMinimalExchangeTradeVolume handling

### DIFF
--- a/octobot_trading/modes/channel/abstract_mode_consumer.py
+++ b/octobot_trading/modes/channel/abstract_mode_consumer.py
@@ -50,9 +50,11 @@ class AbstractTradingModeConsumer(modes_channel.ModeChannelConsumer):
         try:
             await self.create_order_if_possible(symbol, final_note, state, data=data)
         except errors.MissingMinimalExchangeTradeVolume:
+            market_status = self.exchange_manager.exchange.get_market_status(symbol, price_example=None, with_fixer=False)
             self.logger.info(f"Not enough funds to create a new {symbol} order after {final_note} evaluation: "
                              f"{self.exchange_manager.exchange_name} exchange minimal order "
-                             f"volume has not been reached.")
+                             f"volume has not been reached. "
+                             f"Exchanges requirements are: {market_status.get(Ecmsc.LIMITS.value)}")
         except errors.UnhandledContractError as err:
             self.logger.error(f"Unhandled contract error on {self.exchange_manager.exchange_name}: {err}. "
                               f"Please make sure that {symbol} is the full futures contract symbol. "


### PR DESCRIPTION
` 2023-04-10 13:01:53,968 INFO     DCATradingModeConsumer Not enough funds to create a new HRCC/USDT order after None evaluation: hollaex exchange minimal order volume has not been reached. Exchanges requirements are: {'amount': {'min': 10.0, 'max': 10000.0}, 'price': {'min': 1.95, 'max': 100.0}, 'cost': {'min': None, 'max': None}, 'leverage': {'min': None, 'max': None}}`