### PR TITLE
[Portfolio] fix get_global_portfolio_currencies_values on multi exchange

### DIFF
--- a/octobot_trading/api/portfolio.py
+++ b/octobot_trading/api/portfolio.py
@@ -40,14 +40,12 @@ def get_global_portfolio_currencies_values(exchange_managers: list) -> dict:
     currencies_values = {}
     for exchange in exchange_managers:
         this_currency_values = (
-            exchange.exchange_personal_data.portfolio_manager \
-                .portfolio_value_holder.get_current_crypto_currencies_values()
+            exchange.exchange_personal_data.portfolio_manager
+            .portfolio_value_holder.get_current_crypto_currencies_values()
         )
         for currency, value in this_currency_values.items():
             if currency not in currencies_values:
                 currencies_values[currency] = value
-            else:
-                currencies_values[currency] += value
     return currencies_values
 
 


### PR DESCRIPTION
issue:
when an asset in on multiple enabled exchanges, its value is multiplied by the times it appears on exchanges. we want to always keep track of only 1 unit of the asset instead.
fixes https://github.com/Drakkar-Software/OctoBot/issues/2338