### PR TITLE
Mem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.92] - 2024-07-15
+### Fixed
+- [Trades] optimize trade storage RAM
+
 ## [2.4.91] - 2024-07-12
 ### Added
 - [Exchanges] add get_cancelled_orders

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OctoBot-Trading [2.4.91](https://github.com/Drakkar-Software/OctoBot-Trading/blob/master/CHANGELOG.md)
+# OctoBot-Trading [2.4.92](https://github.com/Drakkar-Software/OctoBot-Trading/blob/master/CHANGELOG.md)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/903b6b22bceb4661b608a86fea655f69)](https://app.codacy.com/gh/Drakkar-Software/OctoBot-Trading?utm_source=github.com&utm_medium=referral&utm_content=Drakkar-Software/OctoBot-Trading&utm_campaign=Badge_Grade_Dashboard)
 [![PyPI](https://img.shields.io/pypi/v/OctoBot-Trading.svg)](https://pypi.python.org/pypi/OctoBot-Trading/)
 [![Coverage Status](https://coveralls.io/repos/github/Drakkar-Software/OctoBot-Trading/badge.svg?branch=master)](https://coveralls.io/github/Drakkar-Software/OctoBot-Trading?branch=master)

--- a/octobot_trading/__init__.py
+++ b/octobot_trading/__init__.py
@@ -15,4 +15,4 @@
 #  License along with this library.
 
 PROJECT_NAME = "OctoBot-Trading"
-VERSION = "2.4.91"  # major.minor.revision
+VERSION = "2.4.92"  # major.minor.revision

--- a/octobot_trading/constants.py
+++ b/octobot_trading/constants.py
@@ -177,6 +177,7 @@ BALANCE_CHANNEL = "Balance"
 BALANCE_PROFITABILITY_CHANNEL = "BalanceProfitability"
 POSITIONS_CHANNEL = "Positions"
 INDIVIDUAL_ORDER_SYNC_TIMEOUT = 1 * commons_constants.MINUTE_TO_SECONDS
+MAX_TRADES_COUNT = int(os.getenv("MAX_TRADES_COUNT", "2000"))    # larger values can use a large part of ram
 
 # History
 DEFAULT_SAVED_HISTORICAL_TIMEFRAMES = [commons_enums.TimeFrames.ONE_DAY]

--- a/octobot_trading/storage/trades_storage.py
+++ b/octobot_trading/storage/trades_storage.py
@@ -171,7 +171,8 @@ def _format_trade(trade_dict, exchange_manager, chart, x_multiplier, kind, mode)
         commons_enums.DBRows.FEES_CURRENCY.value: fee[enums.FeePropertyColumns.CURRENCY.value]
         if trade_dict[enums.ExchangeConstantsOrderColumns.FEE.value] else "",
         commons_enums.DBRows.ID.value: trade_dict[enums.ExchangeConstantsOrderColumns.ID.value],
-        commons_enums.DBRows.TRADING_MODE.value: exchange_manager.trading_modes[0].get_name(),
+        commons_enums.DBRows.TRADING_MODE.value: exchange_manager.trading_modes[0].get_name()
+        if exchange_manager.trading_modes else None,
         commons_enums.PlotAttributes.X.value: trade_dict[enums.ExchangeConstantsOrderColumns.TIMESTAMP.value] * x_multiplier,
         commons_enums.PlotAttributes.TEXT.value: f"{tag}{trade_dict[enums.ExchangeConstantsOrderColumns.TYPE.value]} "
                 f"{trade_dict[enums.ExchangeConstantsOrderColumns.SIDE.value]} "


### PR DESCRIPTION
output example:
```
[ Top 20 differences ]
C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\json\decoder.py:353: size=26.3 MiB (+14.0 MiB), count=310591 (+163644), average=89 B
C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py:997: size=18.8 MiB (+12.9 MiB), count=70904 (+49082), average=278 B
C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\copy.py:231: size=3807 KiB (+3795 KiB), count=12697 (+12684), average=307 B
C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\numpy\core\numeric.py:329: size=3391 KiB (+3391 KiB), count=427 (+427), average=8131 B
C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py:995: size=4450 KiB (+3082 KiB), count=71195 (+49307), average=64 B
C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\aiohttp\client_reqrep.py:1158: size=3199 KiB (+2708 KiB), count=9 (+8), average=355 KiB
C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\linecache.py:137: size=2157 KiB (+2157 KiB), count=20666 (+20666), average=107 B
C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\copy.py:76: size=2141 KiB (+2141 KiB), count=11922 (+11922), average=184 B
C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\aiohttp\compression_utils.py:105: size=2079 KiB (+2079 KiB), count=36 (+36), average=57.7 KiB
C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\async_support\kucoin.py:1158: size=2906 KiB (+1442 KiB), count=5060 (+2529), average=588 B
C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\tinydb\table.py:197: size=1236 KiB (+1236 KiB), count=3954 (+3954), average=320 B
C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\async_support\kucoin.py:1353: size=0 B (-1029 KiB), count=0 (-3062)
C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py:496: size=991 KiB (+955 KiB), count=35 (+34), average=28.3 KiB
C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py:1693: size=1312 KiB (+906 KiB), count=55984 (+38651), average=24 B
C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\proactor_events.py:191: size=1281 KiB (+897 KiB), count=40 (+28), average=32.0 KiB
C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\async_support\bitget.py:1919: size=862 KiB (+862 KiB), count=2646 (+2646), average=334 B
C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\async_support\cryptocom.py:534: size=856 KiB (+856 KiB), count=1481 (+1481), average=592 B
C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\copy.py:228: size=800 KiB (+800 KiB), count=12808 (+12792), average=64 B
C:\Users\gdsm\Documents\octobot\OctoBot-Trading\octobot_trading\personal_data\trades\trade.py:29: size=772 KiB (+772 KiB), count=3954 (+3954), average=200 B
C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\async_support\coinex.py:605: size=760 KiB (+760 KiB), count=2319 (+2319), average=336 B
Top 20 lines
#1: C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py:708: 9996.8 KiB
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 708
        return self.on_json_response(http_response)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 573
        return json.loads(response_body, parse_float=str, parse_int=str)
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\json\__init__.py", line 359
        return cls(**kw).decode(s)
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\json\decoder.py", line 337
        obj, end = self.raw_decode(s, idx=_w(s, 0).end())
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\json\decoder.py", line 353
        obj, end = self.scan_once(s, idx)
#2: C:\Users\gdsm\Documents\octobot\OctoBot-Commons\octobot_commons\json_util.py:66: 7859.1 KiB
      File "C:\Users\gdsm\Documents\octobot\OctoBot-Commons\octobot_commons\json_util.py", line 66
        return json.load(open_file)
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\json\__init__.py", line 293
        return loads(fp.read(),
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\json\__init__.py", line 346
        return _default_decoder.decode(s)
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\json\decoder.py", line 337
        obj, end = self.raw_decode(s, idx=_w(s, 0).end())
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\json\decoder.py", line 353
        obj, end = self.scan_once(s, idx)
#3: C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py:708: 7286.8 KiB
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 708
        return self.on_json_response(http_response)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 575
        return json.loads(response_body)
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\json\__init__.py", line 346
        return _default_decoder.decode(s)
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\json\decoder.py", line 337
        obj, end = self.raw_decode(s, idx=_w(s, 0).end())
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\json\decoder.py", line 353
        obj, end = self.scan_once(s, idx)
#4: C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py:997: 3488.1 KiB
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 997
        result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 997
        result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 997
        result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 997
        result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 997
        result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
#5: C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\base_events.py:1909: 3159.4 KiB
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\base_events.py", line 1909
        handle._run()
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\events.py", line 80
        self._context.run(self._callback, *self._args)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\async_support\base\exchange.py", line 263
        return self.set_markets(markets, currencies)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 2549
        market = self.deep_extend(self.safe_market_structure(), {
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 997
        result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
#6: C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\base_events.py:603: 2905.5 KiB
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\base_events.py", line 603
        self._run_once()
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\base_events.py", line 1909
        handle._run()
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\events.py", line 80
        self._context.run(self._callback, *self._args)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\async_support\base\exchange.py", line 262
        markets = await self.fetch_markets(params)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\async_support\kucoin.py", line 1158
        result.append({
#7: C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\async_support\base\exchange.py:263: 2801.1 KiB
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\async_support\base\exchange.py", line 263
        return self.set_markets(markets, currencies)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 2549
        market = self.deep_extend(self.safe_market_structure(), {
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 997
        result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 997
        result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 997
        result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
#8: C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\events.py:80: 2588.9 KiB
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\events.py", line 80
        self._context.run(self._callback, *self._args)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\async_support\base\exchange.py", line 263
        return self.set_markets(markets, currencies)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 2549
        market = self.deep_extend(self.safe_market_structure(), {
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 997
        result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 997
        result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
#9: C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py:2567: 2486.0 KiB
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 2567
        self.currencies = self.deep_extend(self.currencies, currencies)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 997
        result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 997
        result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 997
        result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 997
        result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
#10: C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\events.py:80: 2223.8 KiB
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\events.py", line 80
        self._context.run(self._callback, *self._args)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\async_support\base\exchange.py", line 263
        return self.set_markets(markets, currencies)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 2567
        self.currencies = self.deep_extend(self.currencies, currencies)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 997
        result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 997
        result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
#11: C:\Users\gdsm\Documents\octobot\OctoBot-Commons\octobot_commons\system_resources_watcher.py:77: 2157.1 KiB
      File "C:\Users\gdsm\Documents\octobot\OctoBot-Commons\octobot_commons\system_resources_watcher.py", line 77
        for _line in stat.traceback.format():
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\tracemalloc.py", line 251
        line = linecache.getline(frame.filename, frame.lineno).strip()
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\linecache.py", line 30
        lines = getlines(filename, module_globals)
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\linecache.py", line 46
        return updatecache(filename, module_globals)
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\linecache.py", line 137
        lines = fp.readlines()
#12: C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\proactor_events.py:274: 2078.9 KiB
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\proactor_events.py", line 274
        self._protocol.data_received(data)
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\sslproto.py", line 551
        self._app_protocol.data_received(chunk)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\aiohttp\client_proto.py", line 256
        messages, upgraded, tail = self._parser.feed_data(data)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\aiohttp\http_parser.py", line 994
        chunk = self.decompressor.decompress_sync(chunk)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\aiohttp\compression_utils.py", line 105
        return self._decompressor.decompress(data, max_length)
#13: C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\async_support\base\exchange.py:263: 1876.5 KiB
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\async_support\base\exchange.py", line 263
        return self.set_markets(markets, currencies)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 2567
        self.currencies = self.deep_extend(self.currencies, currencies)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 997
        result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 997
        result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\base\exchange.py", line 997
        result[key] = Exchange.deep_extend(result[key] if key in result else None, arg[key])
#14: C:\Users\gdsm\Documents\octobot\OctoBot-Trading\octobot_trading\exchanges\connectors\ccxt\ccxt_client_util.py:127: 1579.4 KiB
      File "C:\Users\gdsm\Documents\octobot\OctoBot-Trading\octobot_trading\exchanges\connectors\ccxt\ccxt_client_util.py", line 127
        ccxt_clients_cache.get_client_key(client), copy.deepcopy(list(client.markets.values()))
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\copy.py", line 146
        y = copier(x, memo)
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\copy.py", line 206
        append(deepcopy(a, memo))
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\copy.py", line 146
        y = copier(x, memo)
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\copy.py", line 231
        y[deepcopy(key, memo)] = deepcopy(value, memo)
#15: C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\copy.py:206: 1328.8 KiB
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\copy.py", line 206
        append(deepcopy(a, memo))
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\copy.py", line 146
        y = copier(x, memo)
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\copy.py", line 231
        y[deepcopy(key, memo)] = deepcopy(value, memo)
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\copy.py", line 146
        y = copier(x, memo)
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\copy.py", line 231
        y[deepcopy(key, memo)] = deepcopy(value, memo)
#16: C:\Users\gdsm\Documents\octobot\OctoBot-Trading\octobot_trading\storage\trades_storage.py:81: 1235.6 KiB
      File "C:\Users\gdsm\Documents\octobot\OctoBot-Trading\octobot_trading\storage\trades_storage.py", line 81
        [
      File "C:\Users\gdsm\Documents\octobot\OctoBot-Trading\octobot_trading\storage\trades_storage.py", line 82
        _format_trade(
      File "C:\Users\gdsm\Documents\octobot\OctoBot-Trading\octobot_trading\storage\trades_storage.py", line 167
        constants.STORAGE_ORIGIN_VALUE: TradesStorage.sanitize_for_storage(trade_dict),
      File "C:\Users\gdsm\Documents\octobot\OctoBot-Trading\octobot_trading\storage\abstract_storage.py", line 166
        sanitized = copy.copy(element)
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\copy.py", line 76
        return copier(x)
#17: C:\Users\gdsm\Documents\octobot\OctoBot-Commons\octobot_commons\databases\bases\document_database.py:90: 1235.6 KiB
      File "C:\Users\gdsm\Documents\octobot\OctoBot-Commons\octobot_commons\databases\bases\document_database.py", line 90
        return await self.adaptor.insert_many(table_name, rows)
      File "C:\Users\gdsm\Documents\octobot\OctoBot-Commons\octobot_commons\databases\document_database_adaptors\tinydb_adaptor.py", line 259
        return self.database.table(table_name).insert_multiple(rows)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\tinydb\table.py", line 200
        self._update_table(updater)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\tinydb\table.py", line 709
        updater(table)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\tinydb\table.py", line 197
        table[doc_id] = dict(document)
#18: C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\async_support\phemex.py:980: 1118.3 KiB
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\async_support\phemex.py", line 980
        response = await self.v2GetPublicProducts(params)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\async_support\base\exchange.py", line 848
        return await self.fetch2(path, api, method, params, headers, body, config)
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\async_support\base\exchange.py", line 835
        return await self.fetch(request['url'], request['method'], request['headers'], request['body'])
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\ccxt\async_support\base\exchange.py", line 204
        http_response = await response.text(errors='replace')
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\aiohttp\client_reqrep.py", line 1158
        return self._body.decode(  # type: ignore[no-any-return,union-attr]
#19: C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\base_events.py:1103: 1088.9 KiB
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\base_events.py", line 1103
        transport, protocol = await self._create_connection_transport(
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\base_events.py", line 1125
        transport = self._make_ssl_transport(
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\proactor_events.py", line 655
        _ProactorSocketTransport(self, rawsock, ssl_protocol,
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\proactor_events.py", line 609
        super().__init__(loop, sock, protocol, waiter, extra, server)
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\asyncio\proactor_events.py", line 191
        self._data = bytearray(buffer_size)
#20: C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\tinydb\storages.py:125: 1047.2 KiB
      File "C:\Users\gdsm\Documents\octobot\OctoBot\venv\lib\site-packages\tinydb\storages.py", line 125
        return json.load(self._handle)
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\json\__init__.py", line 293
        return loads(fp.read(),
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\json\__init__.py", line 346
        return _default_decoder.decode(s)
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\json\decoder.py", line 337
        obj, end = self.raw_decode(s, idx=_w(s, 0).end())
      File "C:\Users\gdsm\AppData\Local\Programs\Python\Python310\lib\json\decoder.py", line 353
        obj, end = self.scan_once(s, idx)
11049 other: 44601.9 KiB
Total allocated size: 104143.7 KiB
latest_size=167871968, latest_peak=163937.7900390625 largest_peak=163937.7900390625
```